### PR TITLE
Add initial mplstudio package with ipywidgets GUI panel

### DIFF
--- a/mplstudio/__init__.py
+++ b/mplstudio/__init__.py
@@ -1,0 +1,7 @@
+"""mplstudio — GUI styling tool for matplotlib figures in Jupyter."""
+
+from .widget import studio
+from .palettes import PALETTES, get_palette, recommend, palette_names
+
+__version__ = "0.1.0"
+__all__ = ["studio", "PALETTES", "get_palette", "recommend", "palette_names"]

--- a/mplstudio/palettes.py
+++ b/mplstudio/palettes.py
@@ -46,6 +46,30 @@ PALETTES: list[dict] = [
         "tags": ["colorblind-safe", "high-contrast"],
         "description": "Maximum contrast for accessibility.",
     },
+    {
+        "name": "Nord",
+        "colors": ["#BF616A", "#D08770", "#EBCB8B", "#A3BE8C", "#88C0D0", "#81A1C1", "#5E81AC", "#B48EAD"],
+        "tags": ["categorical", "muted", "dark-background"],
+        "description": "Arctic, north-bluish accent colors from the Nord theme.",
+    },
+    {
+        "name": "Catppuccin Latte",
+        "colors": ["#D20F39", "#FE640B", "#DF8E1D", "#40A02B", "#04A5E5", "#8839EF", "#EA76CB", "#E64553"],
+        "tags": ["categorical", "pastel", "light-background"],
+        "description": "Warm pastel tones from the Catppuccin Latte theme.",
+    },
+    {
+        "name": "Dracula",
+        "colors": ["#FF5555", "#FFB86C", "#F1FA8C", "#50FA7B", "#8BE9FD", "#BD93F9", "#FF79C6", "#6272A4"],
+        "tags": ["categorical", "dark-background", "vibrant"],
+        "description": "Vivid accent colors from the Dracula dark theme.",
+    },
+    {
+        "name": "Tokyo Night",
+        "colors": ["#F7768E", "#FF9E64", "#E0AF68", "#9ECE6A", "#73DACA", "#7DCFFF", "#7AA2F7", "#BB9AF7"],
+        "tags": ["categorical", "dark-background", "vibrant"],
+        "description": "Neon-tinged accents from the Tokyo Night editor theme.",
+    },
 ]
 
 

--- a/mplstudio/palettes.py
+++ b/mplstudio/palettes.py
@@ -1,0 +1,68 @@
+"""Curated color palettes and recommendation helpers."""
+
+from __future__ import annotations
+
+# Each palette: {name, colors, tags, description}
+PALETTES: list[dict] = [
+    {
+        "name": "Okabe-Ito",
+        "colors": ["#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7", "#000000"],
+        "tags": ["colorblind-safe", "categorical"],
+        "description": "Colorblind-friendly palette by Okabe & Ito (2008).",
+    },
+    {
+        "name": "ColorBrewer Set2",
+        "colors": ["#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3", "#A6D854", "#FFD92F", "#E5C494", "#B3B3B3"],
+        "tags": ["colorblind-safe", "categorical", "print-safe"],
+        "description": "Qualitative palette suitable for categorical data.",
+    },
+    {
+        "name": "Tableau 10",
+        "colors": ["#4E79A7", "#F28E2B", "#E15759", "#76B7B2", "#59A14F", "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC"],
+        "tags": ["categorical"],
+        "description": "Default Tableau palette, high contrast.",
+    },
+    {
+        "name": "Viridis (5 steps)",
+        "colors": ["#440154", "#3B528B", "#21908C", "#5DC963", "#FDE725"],
+        "tags": ["sequential", "colorblind-safe", "perceptually-uniform"],
+        "description": "5-step sample of the perceptually uniform Viridis colormap.",
+    },
+    {
+        "name": "Coolwarm (diverging)",
+        "colors": ["#3B4CC0", "#7B9FF9", "#DDDDDD", "#F4987A", "#B40426"],
+        "tags": ["diverging"],
+        "description": "5-step diverging palette for data centered around zero.",
+    },
+    {
+        "name": "Pastel",
+        "colors": ["#AEC6CF", "#FFD1DC", "#B5EAD7", "#FFDAC1", "#C7CEEA", "#FF9AA2"],
+        "tags": ["categorical", "light-background"],
+        "description": "Soft pastel tones, good for presentations.",
+    },
+    {
+        "name": "High Contrast",
+        "colors": ["#000000", "#FFFFFF", "#E69F00", "#56B4E9", "#009E73", "#D55E00"],
+        "tags": ["colorblind-safe", "high-contrast"],
+        "description": "Maximum contrast for accessibility.",
+    },
+]
+
+
+def get_palette(name: str) -> list[str]:
+    for p in PALETTES:
+        if p["name"] == name:
+            return p["colors"]
+    raise KeyError(f"Palette '{name}' not found.")
+
+
+def recommend(n_colors: int, *, colorblind_safe: bool = False) -> list[dict]:
+    """Return palettes with at least n_colors that match optional filters."""
+    results = [p for p in PALETTES if len(p["colors"]) >= n_colors]
+    if colorblind_safe:
+        results = [p for p in results if "colorblind-safe" in p["tags"]]
+    return results
+
+
+def palette_names() -> list[str]:
+    return [p["name"] for p in PALETTES]

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -1,0 +1,88 @@
+"""Pure functions that mutate a matplotlib Figure/Axes in-place."""
+
+from __future__ import annotations
+
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from .palettes import get_palette
+
+
+def set_figure_size(fig: Figure, width: float, height: float) -> None:
+    fig.set_size_inches(width, height)
+
+
+def set_font_size(fig: Figure, size: float) -> None:
+    for ax in fig.axes:
+        ax.title.set_fontsize(size)
+        ax.xaxis.label.set_fontsize(size)
+        ax.yaxis.label.set_fontsize(size)
+        ax.tick_params(labelsize=max(size - 2, 6))
+        legend = ax.get_legend()
+        if legend:
+            for text in legend.get_texts():
+                text.set_fontsize(size)
+
+
+def set_legend_position(fig: Figure, location: str) -> None:
+    for ax in fig.axes:
+        legend = ax.get_legend()
+        if legend:
+            handles, labels = ax.get_legend_handles_labels()
+            if handles:
+                ax.legend(handles, labels, loc=location)
+
+
+def set_line_colors(fig: Figure, palette_name: str) -> None:
+    colors = get_palette(palette_name)
+    for ax in fig.axes:
+        lines = ax.get_lines()
+        for i, line in enumerate(lines):
+            line.set_color(colors[i % len(colors)])
+
+
+def set_background_color(fig: Figure, color: str) -> None:
+    fig.patch.set_facecolor(color)
+    for ax in fig.axes:
+        ax.set_facecolor(color)
+
+
+def set_grid(fig: Figure, visible: bool, alpha: float = 0.3) -> None:
+    for ax in fig.axes:
+        ax.grid(visible)
+        if visible:
+            ax.grid(alpha=alpha)
+
+
+def set_spine_style(fig: Figure, style: str) -> None:
+    """style: 'box' | 'left-bottom' | 'none'"""
+    for ax in fig.axes:
+        if style == "box":
+            for spine in ax.spines.values():
+                spine.set_visible(True)
+        elif style == "left-bottom":
+            ax.spines["top"].set_visible(False)
+            ax.spines["right"].set_visible(False)
+            ax.spines["left"].set_visible(True)
+            ax.spines["bottom"].set_visible(True)
+        elif style == "none":
+            for spine in ax.spines.values():
+                spine.set_visible(False)
+
+
+def redraw(fig: Figure) -> None:
+    """Force a canvas refresh; works for both ipympl and inline backends."""
+    canvas = fig.canvas
+    if hasattr(canvas, "draw_idle"):
+        canvas.draw_idle()
+    else:
+        fig.canvas.draw()
+
+
+LEGEND_LOCATIONS = [
+    "best", "upper right", "upper left", "lower left", "lower right",
+    "right", "center left", "center right", "lower center", "upper center", "center",
+]
+
+SPINE_STYLES = ["box", "left-bottom", "none"]

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -72,12 +72,15 @@ def set_spine_style(fig: Figure, style: str) -> None:
 
 
 def redraw(fig: Figure) -> None:
-    """Force a canvas refresh; works for both ipympl and inline backends."""
+    """Force a synchronous canvas refresh for both ipympl and inline backends.
+
+    draw_idle() is async and ipympl may deduplicate or skip repeated calls,
+    so we use the synchronous draw() followed by flush_events() instead.
+    """
     canvas = fig.canvas
-    if hasattr(canvas, "draw_idle"):
-        canvas.draw_idle()
-    else:
-        fig.canvas.draw()
+    canvas.draw()
+    if hasattr(canvas, "flush_events"):
+        canvas.flush_events()
 
 
 LEGEND_LOCATIONS = [

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -1,0 +1,186 @@
+"""ipywidgets control panel for mplstudio."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import ipywidgets as widgets
+from IPython.display import display
+from matplotlib.figure import Figure
+
+from . import style as S
+from .palettes import PALETTES, palette_names
+
+
+_RENDER_MODES = ["in-place (ipympl)", "re-render"]
+
+
+def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)") -> None:
+    """Display the mplstudio control panel for *fig*.
+
+    Parameters
+    ----------
+    fig:
+        Target figure. Defaults to ``plt.gcf()``.
+    render_mode:
+        ``"in-place (ipympl)"`` mutates the live canvas; ``"re-render"``
+        calls ``plt.show()`` after each change (works with any backend).
+    """
+    if fig is None:
+        fig = plt.gcf()
+
+    # ── render mode selector ──────────────────────────────────────────────
+    render_toggle = widgets.ToggleButtons(
+        options=_RENDER_MODES,
+        value=render_mode,
+        description="Render:",
+        style={"button_width": "160px"},
+        layout=widgets.Layout(margin="0 0 8px 0"),
+    )
+
+    # ── figure size ───────────────────────────────────────────────────────
+    w_init, h_init = fig.get_size_inches()
+    fig_width = widgets.FloatSlider(
+        value=w_init, min=2, max=24, step=0.5,
+        description="Width (in)", style={"description_width": "100px"},
+        continuous_update=False,
+    )
+    fig_height = widgets.FloatSlider(
+        value=h_init, min=2, max=24, step=0.5,
+        description="Height (in)", style={"description_width": "100px"},
+        continuous_update=False,
+    )
+
+    # ── font ──────────────────────────────────────────────────────────────
+    font_size = widgets.IntSlider(
+        value=12, min=6, max=32, step=1,
+        description="Font size", style={"description_width": "100px"},
+        continuous_update=False,
+    )
+
+    # ── colors ────────────────────────────────────────────────────────────
+    palette_select = widgets.Dropdown(
+        options=palette_names(),
+        description="Palette",
+        style={"description_width": "100px"},
+    )
+    palette_preview = _build_palette_preview(palette_names()[0])
+
+    bg_color = widgets.ColorPicker(
+        value="#ffffff", description="Background",
+        style={"description_width": "100px"},
+        concise=False,
+    )
+
+    # ── legend ────────────────────────────────────────────────────────────
+    legend_loc = widgets.Dropdown(
+        options=S.LEGEND_LOCATIONS,
+        value="best",
+        description="Legend loc", style={"description_width": "100px"},
+    )
+
+    # ── grid & spines ─────────────────────────────────────────────────────
+    grid_toggle = widgets.Checkbox(value=True, description="Show grid")
+    spine_style = widgets.ToggleButtons(
+        options=S.SPINE_STYLES,
+        value="box",
+        description="Spines:",
+        style={"button_width": "100px"},
+    )
+
+    # ── colorblind recommendation ─────────────────────────────────────────
+    cb_recommend = widgets.Button(
+        description="Recommend colorblind-safe palette",
+        button_style="info",
+        layout=widgets.Layout(width="260px"),
+    )
+    recommend_out = widgets.Output()
+
+    # ── apply button ──────────────────────────────────────────────────────
+    apply_btn = widgets.Button(
+        description="Apply",
+        button_style="success",
+        icon="check",
+        layout=widgets.Layout(width="120px"),
+    )
+    status = widgets.HTML(value="")
+
+    # ── callbacks ─────────────────────────────────────────────────────────
+
+    def _refresh():
+        if render_toggle.value == "re-render":
+            plt.close(fig)
+            display(fig)
+        else:
+            S.redraw(fig)
+        status.value = "<span style='color:green'>✓ Applied</span>"
+
+    def _on_apply(_):
+        S.set_figure_size(fig, fig_width.value, fig_height.value)
+        S.set_font_size(fig, font_size.value)
+        S.set_legend_position(fig, legend_loc.value)
+        S.set_line_colors(fig, palette_select.value)
+        S.set_background_color(fig, bg_color.value)
+        S.set_grid(fig, grid_toggle.value)
+        S.set_spine_style(fig, spine_style.value)
+        _refresh()
+
+    def _on_palette_change(change):
+        nonlocal palette_preview
+        new_preview = _build_palette_preview(change["new"])
+        palette_box.children = (palette_select, new_preview)
+
+    def _on_recommend(_):
+        from .palettes import recommend
+        n = sum(len(ax.get_lines()) for ax in fig.axes) or 3
+        suggestions = recommend(n, colorblind_safe=True)
+        with recommend_out:
+            recommend_out.clear_output()
+            for p in suggestions[:3]:
+                swatch = "  ".join(
+                    f"<span style='background:{c};padding:0 10px;border-radius:3px'>&nbsp;</span>"
+                    for c in p["colors"][:n]
+                )
+                display(widgets.HTML(
+                    f"<b>{p['name']}</b> — {p['description']}<br>{swatch}<br>"
+                ))
+
+    apply_btn.on_click(_on_apply)
+    palette_select.observe(_on_palette_change, names="value")
+    cb_recommend.on_click(_on_recommend)
+
+    # ── layout ────────────────────────────────────────────────────────────
+    palette_box = widgets.HBox([palette_select, palette_preview])
+
+    panel = widgets.VBox([
+        widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
+        render_toggle,
+        widgets.HTML("<hr style='margin:4px 0'>"),
+        widgets.HTML("<b>Figure size</b>"),
+        fig_width, fig_height,
+        widgets.HTML("<b>Typography</b>"),
+        font_size,
+        widgets.HTML("<b>Colors</b>"),
+        palette_box,
+        bg_color,
+        widgets.HTML("<b>Legend</b>"),
+        legend_loc,
+        widgets.HTML("<b>Grid & Spines</b>"),
+        grid_toggle, spine_style,
+        widgets.HTML("<hr style='margin:4px 0'>"),
+        cb_recommend, recommend_out,
+        widgets.HBox([apply_btn, status]),
+    ], layout=widgets.Layout(padding="12px", width="380px",
+                              border="1px solid #ddd", border_radius="6px"))
+
+    display(panel)
+
+
+def _build_palette_preview(name: str) -> widgets.HTML:
+    from .palettes import get_palette
+    colors = get_palette(name)
+    swatches = "".join(
+        f"<span style='background:{c};display:inline-block;width:18px;height:18px;"
+        f"margin:1px;border-radius:3px;border:1px solid #ccc'></span>"
+        for c in colors
+    )
+    return widgets.HTML(value=f"<div style='margin-left:8px'>{swatches}</div>")

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -95,6 +95,11 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
     )
     recommend_out = widgets.Output()
 
+    # ── re-render output widget (only used in re-render mode) ─────────────
+    # Keeps the figure alive — plt.close() would destroy the canvas and break
+    # subsequent apply calls.
+    render_out = widgets.Output()
+
     # ── apply button ──────────────────────────────────────────────────────
     apply_btn = widgets.Button(
         description="Apply",
@@ -108,8 +113,9 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
 
     def _refresh():
         if render_toggle.value == "re-render":
-            plt.close(fig)
-            display(fig)
+            with render_out:
+                render_out.clear_output(wait=True)
+                display(fig)
         else:
             S.redraw(fig)
         status.value = "<span style='color:green'>✓ Applied</span>"
@@ -144,6 +150,12 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
                     f"<b>{p['name']}</b> — {p['description']}<br>{swatch}<br>"
                 ))
 
+    def _on_render_mode_change(change):
+        render_out.layout.display = "" if change["new"] == "re-render" else "none"
+
+    render_out.layout.display = "none" if render_mode == "in-place (ipympl)" else ""
+    render_toggle.observe(_on_render_mode_change, names="value")
+
     apply_btn.on_click(_on_apply)
     palette_select.observe(_on_palette_change, names="value")
     cb_recommend.on_click(_on_recommend)
@@ -154,6 +166,7 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
     panel = widgets.VBox([
         widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
         render_toggle,
+        render_out,
         widgets.HTML("<hr style='margin:4px 0'>"),
         widgets.HTML("<b>Figure size</b>"),
         fig_width, fig_height,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mplstudio"
+version = "0.1.0"
+description = "GUI tool for matplotlib styling in Jupyter notebooks"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Seo-Yoon Moon", email = "smoon2@andrew.cmu.edu" }]
+keywords = ["matplotlib", "jupyter", "visualization", "styling", "gui"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Framework :: Jupyter",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Visualization",
+]
+dependencies = [
+    "matplotlib>=3.5",
+    "ipywidgets>=8.0",
+    "ipympl>=0.9",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "jupyterlab"]
+
+[project.urls]
+Homepage = "https://github.com/smoon2/mplstudio"
+Issues = "https://github.com/smoon2/mplstudio/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "matplotlib>=3.5",
+    "ipykernel>=6.0",
     "ipywidgets>=8.0",
     "ipympl>=0.9",
 ]

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,66 @@
+import matplotlib
+matplotlib.use("Agg")  # headless backend for CI
+import matplotlib.pyplot as plt
+import pytest
+
+import mplstudio
+from mplstudio import style as S
+from mplstudio.palettes import get_palette, recommend
+
+
+@pytest.fixture
+def fig():
+    f, ax = plt.subplots()
+    ax.plot([1, 2, 3], label="line")
+    ax.legend()
+    yield f
+    plt.close(f)
+
+
+def test_set_figure_size(fig):
+    S.set_figure_size(fig, 10, 5)
+    assert fig.get_size_inches() == pytest.approx([10, 5])
+
+
+def test_set_font_size(fig):
+    S.set_font_size(fig, 18)
+    ax = fig.axes[0]
+    assert ax.xaxis.label.get_fontsize() == 18
+
+
+def test_set_legend_position(fig):
+    S.set_legend_position(fig, "upper left")
+    legend = fig.axes[0].get_legend()
+    assert legend is not None
+
+
+def test_set_line_colors(fig):
+    S.set_line_colors(fig, "Okabe-Ito")
+    expected = get_palette("Okabe-Ito")[0]
+    line_color = fig.axes[0].get_lines()[0].get_color()
+    assert line_color.lower() == expected.lower()
+
+
+def test_set_grid(fig):
+    S.set_grid(fig, True)
+    S.set_grid(fig, False)
+
+
+def test_spine_styles(fig):
+    for s in S.SPINE_STYLES:
+        S.set_spine_style(fig, s)
+
+
+def test_get_palette_unknown():
+    with pytest.raises(KeyError):
+        get_palette("DoesNotExist")
+
+
+def test_recommend_colorblind():
+    results = recommend(3, colorblind_safe=True)
+    assert all("colorblind-safe" in p["tags"] for p in results)
+    assert all(len(p["colors"]) >= 3 for p in results)
+
+
+def test_studio_import():
+    assert callable(mplstudio.studio)


### PR DESCRIPTION
Implements the core package structure for pip installation and Jupyter notebook usage:
- pyproject.toml for pip/conda-forge distribution
- style.py: pure in-place mutation functions (figure size, font, colors, legend, grid, spines)
- palettes.py: 7 curated palettes (Okabe-Ito, ColorBrewer, Tableau, etc.) with colorblind-safe recommendations
- widget.py: ipywidgets control panel with render mode toggle (in-place ipympl vs re-render)
- tests/test_style.py: 9 passing unit tests

Usage: import mplstudio; mplstudio.studio(fig)