### PR TITLE
feat: interactive styling panel with auto-refresh and responsive layout

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# mplstudio demo\n",
+    "\n",
+    "Interactive GUI for styling matplotlib figures in Jupyter.\n",
+    "\n",
+    "**Install:**\n",
+    "```bash\n",
+    "pip install mplstudio\n",
+    "```\n",
+    "\n",
+    "No special backend needed — just standard `matplotlib`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Line plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import mplstudio\n",
+    "\n",
+    "x = np.linspace(0, 2 * np.pi, 200)\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(x, np.sin(x), label='sin(x)')\n",
+    "ax.plot(x, np.cos(x), label='cos(x)')\n",
+    "ax.plot(x, np.sin(2 * x), label='sin(2x)')\n",
+    "ax.set_xlabel('x')\n",
+    "ax.set_ylabel('y')\n",
+    "ax.set_title('Trigonometric functions')\n",
+    "ax.legend()\n",
+    "plt.close()  # suppress inline auto-display; studio() will render it\n",
+    "\n",
+    "mplstudio.studio(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Scatter plot\n",
+    "\n",
+    "Color pickers and palette changes work on scatter series too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)\n",
+    "\n",
+    "fig2, ax2 = plt.subplots()\n",
+    "ax2.scatter(np.random.randn(60), np.random.randn(60), label='group A', alpha=0.7)\n",
+    "ax2.scatter(np.random.randn(60), np.random.randn(60), label='group B', alpha=0.7)\n",
+    "ax2.scatter(np.random.randn(60), np.random.randn(60), label='group C', alpha=0.7)\n",
+    "ax2.set_title('Scatter groups')\n",
+    "ax2.legend()\n",
+    "plt.close()\n",
+    "\n",
+    "mplstudio.studio(fig2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Programmatic API\n",
+    "\n",
+    "All style functions in `mplstudio.style` work without the GUI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mplstudio import style as S\n",
+    "\n",
+    "fig3, ax3 = plt.subplots()\n",
+    "ax3.plot([1, 4, 2, 5, 3], label='series')\n",
+    "ax3.legend()\n",
+    "\n",
+    "S.set_figure_size(fig3, 8, 4)\n",
+    "S.set_font_size(fig3, 14)\n",
+    "S.set_line_colors(fig3, 'Okabe-Ito')\n",
+    "S.set_spine_style(fig3, 'left-bottom')\n",
+    "S.set_grid(fig3, True)\n",
+    "S.set_legend_position(fig3, 'upper right')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Color palette preview"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.patches as mpatches\n",
+    "\n",
+    "palettes = mplstudio.PALETTES\n",
+    "fig4, axes = plt.subplots(len(palettes), 1, figsize=(10, len(palettes) * 0.6))\n",
+    "\n",
+    "for ax, p in zip(axes, palettes):\n",
+    "    for i, color in enumerate(p['colors']):\n",
+    "        ax.add_patch(mpatches.Rectangle((i, 0), 1, 1, color=color))\n",
+    "    ax.set_xlim(0, max(len(p['colors']), 8))\n",
+    "    ax.set_ylim(0, 1)\n",
+    "    ax.set_yticks([])\n",
+    "    ax.set_xticks([])\n",
+    "    ax.set_ylabel(p['name'], rotation=0, ha='right', va='center', fontsize=9)\n",
+    "\n",
+    "fig4.suptitle('Built-in palettes', y=1.01, fontsize=12)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -35,12 +35,29 @@ def set_legend_position(fig: Figure, location: str) -> None:
                 ax.legend(handles, labels, loc=location)
 
 
+def _sync_legend_colors(ax) -> None:
+    """Update legend handle colors to match the current line colors.
+
+    Legend handles are independent Line2D copies, so changing the original
+    line color does not automatically update the legend swatch.
+    """
+    legend = ax.get_legend()
+    if legend is None:
+        return
+    lines = ax.get_lines()
+    for handle, line in zip(legend.legend_handles, lines):
+        try:
+            handle.set_color(line.get_color())
+        except AttributeError:
+            pass
+
+
 def set_line_colors(fig: Figure, palette_name: str) -> None:
     colors = get_palette(palette_name)
     for ax in fig.axes:
-        lines = ax.get_lines()
-        for i, line in enumerate(lines):
+        for i, line in enumerate(ax.get_lines()):
             line.set_color(colors[i % len(colors)])
+        _sync_legend_colors(ax)
 
 
 def set_line_colors_manual(fig: Figure, colors: list[str]) -> None:
@@ -48,6 +65,8 @@ def set_line_colors_manual(fig: Figure, colors: list[str]) -> None:
     all_lines = [line for ax in fig.axes for line in ax.get_lines()]
     for line, color in zip(all_lines, colors):
         line.set_color(color)
+    for ax in fig.axes:
+        _sync_legend_colors(ax)
 
 
 def get_line_colors(fig: Figure) -> list[str]:

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -2,13 +2,85 @@
 
 from __future__ import annotations
 
-import matplotlib
 import matplotlib.colors as mcolors
-import matplotlib.pyplot as plt
+from matplotlib.collections import PathCollection
 from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
 
 from .palettes import get_palette
 
+
+# ── artist helpers ────────────────────────────────────────────────────────────
+
+def _labeled_artists(ax):
+    """Yield (actual_artist, label) for every legend-visible series, in legend order.
+
+    Works for both Line2D (line plots) and PathCollection (scatter plots).
+    Matches legend labels to actual axes artists so both can be coloured.
+    """
+    handles, labels = ax.get_legend_handles_labels()
+    # Build label→actual-artist lookup (first occurrence wins)
+    candidates: dict[str, object] = {}
+    for a in (*ax.get_lines(), *ax.collections):
+        lbl = a.get_label()
+        if lbl and not lbl.startswith("_") and lbl not in candidates:
+            candidates[lbl] = a
+    for _, label in zip(handles, labels):
+        if label in candidates:
+            yield candidates[label], label
+
+
+def _get_artist_color(artist) -> str:
+    if isinstance(artist, Line2D):
+        return mcolors.to_hex(artist.get_color())
+    if isinstance(artist, PathCollection):
+        fc = artist.get_facecolor()
+        if len(fc):
+            return mcolors.to_hex(fc[0, :3])
+    return "#000000"
+
+
+def _set_artist_color(artist, color: str) -> None:
+    if isinstance(artist, Line2D):
+        artist.set_color(color)
+    elif isinstance(artist, PathCollection):
+        artist.set_facecolor(color)
+        artist.set_edgecolor(color)
+
+
+def _sync_legend_colors(ax) -> None:
+    """Update legend handle colors to match the current artist colors.
+
+    ax.get_legend_handles_labels() returns the original axes artists, not the
+    legend's internal handle copies. We must iterate legend.legend_handles
+    directly and match by label from legend.get_texts().
+    """
+    legend = ax.get_legend()
+    if legend is None:
+        return
+    legend_handles = legend.legend_handles
+    legend_labels = [t.get_text() for t in legend.get_texts()]
+    candidates: dict[str, object] = {}
+    for a in (*ax.get_lines(), *ax.collections):
+        lbl = a.get_label()
+        if lbl and not lbl.startswith("_") and lbl not in candidates:
+            candidates[lbl] = a
+    for handle, label in zip(legend_handles, legend_labels):
+        artist = candidates.get(label)
+        if artist is None:
+            continue
+        color = _get_artist_color(artist)
+        try:
+            handle.set_color(color)
+        except AttributeError:
+            try:
+                handle.set_facecolor(color)
+                handle.set_edgecolor(color)
+            except AttributeError:
+                pass
+
+
+# ── public style functions ────────────────────────────────────────────────────
 
 def set_figure_size(fig: Figure, width: float, height: float) -> None:
     fig.set_size_inches(width, height)
@@ -35,59 +107,43 @@ def set_legend_position(fig: Figure, location: str) -> None:
                 ax.legend(handles, labels, loc=location)
 
 
-def _sync_legend_colors(ax) -> None:
-    """Update legend handle colors to match the current line colors.
-
-    Legend handles are independent Line2D copies, so changing the original
-    line color does not automatically update the legend swatch.
-    """
-    legend = ax.get_legend()
-    if legend is None:
-        return
-    lines = ax.get_lines()
-    for handle, line in zip(legend.legend_handles, lines):
-        try:
-            handle.set_color(line.get_color())
-        except AttributeError:
-            pass
-
-
 def set_line_colors(fig: Figure, palette_name: str) -> None:
     colors = get_palette(palette_name)
+    idx = 0
     for ax in fig.axes:
-        for i, line in enumerate(ax.get_lines()):
-            line.set_color(colors[i % len(colors)])
+        for artist, _ in _labeled_artists(ax):
+            _set_artist_color(artist, colors[idx % len(colors)])
+            idx += 1
         _sync_legend_colors(ax)
 
 
 def set_line_colors_manual(fig: Figure, colors: list[str]) -> None:
-    """Apply per-line colors from a list of hex strings, one entry per line."""
-    all_lines = [line for ax in fig.axes for line in ax.get_lines()]
-    for line, color in zip(all_lines, colors):
-        line.set_color(color)
+    """Apply per-series colors from a list of hex strings, matching legend order."""
+    idx = 0
     for ax in fig.axes:
+        for artist, _ in _labeled_artists(ax):
+            if idx < len(colors):
+                _set_artist_color(artist, colors[idx])
+            idx += 1
         _sync_legend_colors(ax)
 
 
 def get_line_colors(fig: Figure) -> list[str]:
-    """Return current hex color of every line in the figure, in draw order."""
+    """Return current hex color of every labeled series, in legend order."""
     return [
-        mcolors.to_hex(line.get_color())
+        _get_artist_color(artist)
         for ax in fig.axes
-        for line in ax.get_lines()
+        for artist, _ in _labeled_artists(ax)
     ]
 
 
 def get_line_labels(fig: Figure) -> list[str]:
-    """Return display labels for every line (falls back to 'Line N')."""
-    labels = []
-    n = 0
-    for ax in fig.axes:
-        for line in ax.get_lines():
-            n += 1
-            lbl = line.get_label()
-            labels.append(lbl if lbl and not lbl.startswith("_") else f"Line {n}")
-    return labels
+    """Return legend labels for every labeled series, in legend order."""
+    return [
+        label
+        for ax in fig.axes
+        for _, label in _labeled_artists(ax)
+    ]
 
 
 def set_background_color(fig: Figure, color: str) -> None:
@@ -120,11 +176,7 @@ def set_spine_style(fig: Figure, style: str) -> None:
 
 
 def redraw(fig: Figure) -> None:
-    """Force a synchronous canvas refresh for both ipympl and inline backends.
-
-    draw_idle() is async and ipympl may deduplicate or skip repeated calls,
-    so we use the synchronous draw() followed by flush_events() instead.
-    """
+    """Force a synchronous canvas refresh."""
     canvas = fig.canvas
     canvas.draw()
     if hasattr(canvas, "flush_events"):

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import matplotlib
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
@@ -40,6 +41,34 @@ def set_line_colors(fig: Figure, palette_name: str) -> None:
         lines = ax.get_lines()
         for i, line in enumerate(lines):
             line.set_color(colors[i % len(colors)])
+
+
+def set_line_colors_manual(fig: Figure, colors: list[str]) -> None:
+    """Apply per-line colors from a list of hex strings, one entry per line."""
+    all_lines = [line for ax in fig.axes for line in ax.get_lines()]
+    for line, color in zip(all_lines, colors):
+        line.set_color(color)
+
+
+def get_line_colors(fig: Figure) -> list[str]:
+    """Return current hex color of every line in the figure, in draw order."""
+    return [
+        mcolors.to_hex(line.get_color())
+        for ax in fig.axes
+        for line in ax.get_lines()
+    ]
+
+
+def get_line_labels(fig: Figure) -> list[str]:
+    """Return display labels for every line (falls back to 'Line N')."""
+    labels = []
+    n = 0
+    for ax in fig.axes:
+        for line in ax.get_lines():
+            n += 1
+            lbl = line.get_label()
+            labels.append(lbl if lbl and not lbl.startswith("_") else f"Line {n}")
+    return labels
 
 
 def set_background_color(fig: Figure, color: str) -> None:

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -15,48 +15,6 @@ from .palettes import PALETTES, palette_names
 
 _PREVIEW_HEIGHT = 400  # px — fixed height for the fitted preview mode
 
-# CSS that turns the ToggleButton with class "mplstudio-size-toggle" into an
-# iOS-style switch.  We use ::after for the knob and mod-active (added by
-# ipywidgets when value=True) to slide it across.
-_TOGGLE_SWITCH_CSS = """
-<style>
-.mplstudio-size-toggle button.widget-toggle-button {
-    appearance: none !important;
-    -webkit-appearance: none !important;
-    background: #ccc !important;
-    border: none !important;
-    border-radius: 14px !important;
-    box-shadow: inset 0 1px 2px rgba(0,0,0,.15) !important;
-    cursor: pointer !important;
-    font-size: 0 !important;
-    height: 28px !important;
-    overflow: visible !important;
-    padding: 0 !important;
-    position: relative !important;
-    transition: background 0.25s !important;
-    width: 52px !important;
-}
-.mplstudio-size-toggle button.widget-toggle-button::after {
-    background: white;
-    border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(0,0,0,.30);
-    content: '';
-    height: 22px;
-    left: 3px;
-    position: absolute;
-    top: 3px;
-    transition: transform 0.25s;
-    width: 22px;
-}
-.mplstudio-size-toggle button.widget-toggle-button.mod-active {
-    background: #4a9eff !important;
-}
-.mplstudio-size-toggle button.widget-toggle-button.mod-active::after {
-    transform: translateX(24px);
-}
-</style>
-"""
-
 
 def studio(fig: Figure | None = None) -> None:
     """Display the mplstudio control panel for *fig*.
@@ -73,36 +31,49 @@ def studio(fig: Figure | None = None) -> None:
     if fig is None:
         fig = plt.gcf()
 
-    # ── size toggle (fitted preview vs actual size) ───────────────────────
-    size_toggle = widgets.ToggleButton(
-        value=False,
-        description="",
-        layout=widgets.Layout(width="52px", height="28px"),
-    )
-    size_toggle.add_class("mplstudio-size-toggle")
+    # ── size toggle ───────────────────────────────────────────────────────
+    # A hidden Checkbox holds the Python state; the visual is a pure
+    # HTML/CSS toggle switch (user-supplied design) whose onchange handler
+    # dispatches a change event on the hidden checkbox input so ipywidgets
+    # picks it up without any Jupyter-version-specific comm calls.
+    _size_cb = widgets.Checkbox(value=False, indent=False, description="")
+    _size_cb.layout.display = "none"
+    _mid = _size_cb.model_id
 
-    toggle_css = widgets.HTML(_TOGGLE_SWITCH_CSS)
-    toggle_label = widgets.HTML(
-        "<span style='font-size:12px;color:#888;margin-left:6px'>Fitted</span>"
-    )
+    _toggle_html = widgets.HTML(f"""
+<style>
+.mpl-sw-{_mid[:8]} {{
+    position: relative; display: inline-block;
+    width: 60px; height: 34px; vertical-align: middle;
+}}
+.mpl-sw-{_mid[:8]} input {{ opacity: 0; width: 0; height: 0; }}
+.mpl-sl-{_mid[:8]} {{
+    position: absolute; cursor: pointer;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-color: #ccc; transition: .4s; border-radius: 34px;
+}}
+.mpl-sl-{_mid[:8]}:before {{
+    position: absolute; content: "";
+    height: 26px; width: 26px; left: 4px; bottom: 4px;
+    background-color: white; transition: .4s; border-radius: 50%;
+}}
+.mpl-sw-{_mid[:8]} input:checked + .mpl-sl-{_mid[:8]} {{ background-color: #2196F3; }}
+.mpl-sw-{_mid[:8]} input:checked + .mpl-sl-{_mid[:8]}:before {{ transform: translateX(26px); }}
+</style>
+<label class="mpl-sw-{_mid[:8]}" style="vertical-align:middle;cursor:pointer">
+  <input type="checkbox" onchange="
+    var cb = document.querySelector('[data-model-id=\\"{_mid}\\"] input[type=checkbox]');
+    if (cb) {{ cb.checked = this.checked; cb.dispatchEvent(new Event('change', {{bubbles:true}})); }}
+  ">
+  <span class="mpl-sl-{_mid[:8]}"></span>
+</label>
+<span style="margin-left:8px;font-size:13px;color:#555;vertical-align:middle">Actual size</span>
+""")
+
     toggle_row = widgets.HBox(
-        [toggle_css, size_toggle, toggle_label],
+        [_toggle_html, _size_cb],
         layout=widgets.Layout(align_items="center"),
     )
-
-    def _on_size_toggle(change):
-        if change["new"]:
-            toggle_label.value = (
-                "<span style='font-size:12px;color:#4a9eff;"
-                "margin-left:6px;font-weight:600'>Actual size</span>"
-            )
-        else:
-            toggle_label.value = (
-                "<span style='font-size:12px;color:#888;margin-left:6px'>Fitted</span>"
-            )
-        _refresh()
-
-    size_toggle.observe(_on_size_toggle, names="value")
 
     # ── rendered output ───────────────────────────────────────────────────
     render_out = widgets.Output(
@@ -115,18 +86,19 @@ def studio(fig: Figure | None = None) -> None:
         buf.seek(0)
         img_b64 = base64.b64encode(buf.read()).decode()
 
-        if size_toggle.value:
-            # actual size — natural pixel dimensions; wrapper scrolls horizontally
-            # if the figure is wider than the notebook
-            img_style = "height:auto;display:block"
-            div_style = "overflow-x:auto;width:100%"
+        if _size_cb.value:
+            # Actual size: natural pixel dimensions.
+            # text-align:center centers the image when narrower than the
+            # panel; overflow-x:auto adds a scrollbar when wider.
+            div_style = "text-align:center;overflow-x:auto;width:100%"
+            img_style = "height:auto;display:inline-block;vertical-align:top"
         else:
-            # fitted preview — capped height keeps the control panel in place
+            # Fitted: cap height so the control panel doesn't jump.
+            div_style = "text-align:center;width:100%"
             img_style = (
                 f"max-height:{_PREVIEW_HEIGHT}px;width:auto;"
-                "max-width:100%;display:block;margin:0 auto"
+                "max-width:100%;display:inline-block;vertical-align:top"
             )
-            div_style = "width:100%"
 
         img_html = (
             f'<div style="{div_style}">'
@@ -136,6 +108,8 @@ def studio(fig: Figure | None = None) -> None:
         with render_out:
             render_out.clear_output(wait=True)
             display(widgets.HTML(img_html))
+
+    _size_cb.observe(lambda _: _refresh(), names="value")
     _refresh()  # initial render
 
     # ── figure size ───────────────────────────────────────────────────────

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import io
+
 import matplotlib.pyplot as plt
 import ipywidgets as widgets
-from IPython.display import display
+from IPython.display import display, Image
 from matplotlib.figure import Figure
 
 import matplotlib.colors as mcolors
@@ -143,9 +145,14 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
 
     def _refresh():
         if render_toggle.value == "re-render":
+            # savefig() always calls canvas.draw() internally, guaranteeing
+            # the latest artist state is rendered regardless of backend cache.
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png", bbox_inches="tight", dpi=fig.dpi)
+            buf.seek(0)
             with render_out:
                 render_out.clear_output(wait=True)
-                display(fig)
+                display(Image(buf.read()))
         else:
             S.redraw(fig)
         status.value = "<span style='color:green'>✓ Applied</span>"

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -15,6 +15,48 @@ from .palettes import PALETTES, palette_names
 
 _PREVIEW_HEIGHT = 400  # px — fixed height for the fitted preview mode
 
+# CSS that turns the ToggleButton with class "mplstudio-size-toggle" into an
+# iOS-style switch.  We use ::after for the knob and mod-active (added by
+# ipywidgets when value=True) to slide it across.
+_TOGGLE_SWITCH_CSS = """
+<style>
+.mplstudio-size-toggle button.widget-toggle-button {
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    background: #ccc !important;
+    border: none !important;
+    border-radius: 14px !important;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,.15) !important;
+    cursor: pointer !important;
+    font-size: 0 !important;
+    height: 28px !important;
+    overflow: visible !important;
+    padding: 0 !important;
+    position: relative !important;
+    transition: background 0.25s !important;
+    width: 52px !important;
+}
+.mplstudio-size-toggle button.widget-toggle-button::after {
+    background: white;
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0,0,0,.30);
+    content: '';
+    height: 22px;
+    left: 3px;
+    position: absolute;
+    top: 3px;
+    transition: transform 0.25s;
+    width: 22px;
+}
+.mplstudio-size-toggle button.widget-toggle-button.mod-active {
+    background: #4a9eff !important;
+}
+.mplstudio-size-toggle button.widget-toggle-button.mod-active::after {
+    transform: translateX(24px);
+}
+</style>
+"""
+
 
 def studio(fig: Figure | None = None) -> None:
     """Display the mplstudio control panel for *fig*.
@@ -34,24 +76,30 @@ def studio(fig: Figure | None = None) -> None:
     # ── size toggle (fitted preview vs actual size) ───────────────────────
     size_toggle = widgets.ToggleButton(
         value=False,
-        description="Fitted",
-        icon="expand",
-        button_style="",
-        layout=widgets.Layout(width="110px", height="28px"),
-        tooltip="Currently fitted — click to show at actual rendered size",
+        description="",
+        layout=widgets.Layout(width="52px", height="28px"),
+    )
+    size_toggle.add_class("mplstudio-size-toggle")
+
+    toggle_css = widgets.HTML(_TOGGLE_SWITCH_CSS)
+    toggle_label = widgets.HTML(
+        "<span style='font-size:12px;color:#888;margin-left:6px'>Fitted</span>"
+    )
+    toggle_row = widgets.HBox(
+        [toggle_css, size_toggle, toggle_label],
+        layout=widgets.Layout(align_items="center"),
     )
 
     def _on_size_toggle(change):
         if change["new"]:
-            size_toggle.description = "Actual size"
-            size_toggle.icon = "compress"
-            size_toggle.button_style = "info"
-            size_toggle.tooltip = "Currently actual size — click to fit to panel"
+            toggle_label.value = (
+                "<span style='font-size:12px;color:#4a9eff;"
+                "margin-left:6px;font-weight:600'>Actual size</span>"
+            )
         else:
-            size_toggle.description = "Fitted"
-            size_toggle.icon = "expand"
-            size_toggle.button_style = ""
-            size_toggle.tooltip = "Currently fitted — click to show at actual rendered size"
+            toggle_label.value = (
+                "<span style='font-size:12px;color:#888;margin-left:6px'>Fitted</span>"
+            )
         _refresh()
 
     size_toggle.observe(_on_size_toggle, names="value")
@@ -300,7 +348,7 @@ def studio(fig: Figure | None = None) -> None:
     header = widgets.HBox(
         [
             widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
-            size_toggle,
+            toggle_row,
         ],
         layout=widgets.Layout(
             justify_content="space-between",

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -9,233 +9,256 @@ import ipywidgets as widgets
 from IPython.display import display, Image
 from matplotlib.figure import Figure
 
-import matplotlib.colors as mcolors
-
 from . import style as S
 from .palettes import PALETTES, palette_names
 
 
-_RENDER_MODES = ["in-place (ipympl)", "re-render"]
-
-
-def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)") -> None:
+def studio(fig: Figure | None = None) -> None:
     """Display the mplstudio control panel for *fig*.
+
+    The panel embeds a live-rendered image at the top and a responsive
+    grid of controls below. Every widget change auto-refreshes the figure
+    immediately — no Apply button needed.
 
     Parameters
     ----------
     fig:
         Target figure. Defaults to ``plt.gcf()``.
-    render_mode:
-        ``"in-place (ipympl)"`` mutates the live canvas; ``"re-render"``
-        calls ``plt.show()`` after each change (works with any backend).
     """
     if fig is None:
         fig = plt.gcf()
 
-    # ── render mode selector ──────────────────────────────────────────────
-    render_toggle = widgets.ToggleButtons(
-        options=_RENDER_MODES,
-        value=render_mode,
-        description="Render:",
-        style={"button_width": "160px"},
-        layout=widgets.Layout(margin="0 0 8px 0"),
+    # ── rendered output ───────────────────────────────────────────────────
+    render_out = widgets.Output(
+        layout=widgets.Layout(width="100%", margin="0 0 8px 0")
     )
+
+    def _refresh(*_):
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", bbox_inches="tight", dpi=fig.dpi)
+        buf.seek(0)
+        with render_out:
+            render_out.clear_output(wait=True)
+            display(Image(buf.read()))
+
+    _refresh()  # initial render
 
     # ── figure size ───────────────────────────────────────────────────────
     w_init, h_init = fig.get_size_inches()
     fig_width = widgets.FloatSlider(
         value=w_init, min=2, max=24, step=0.5,
-        description="Width (in)", style={"description_width": "100px"},
+        description="Width (in)", style={"description_width": "82px"},
+        layout=widgets.Layout(width="100%"),
         continuous_update=False,
     )
     fig_height = widgets.FloatSlider(
         value=h_init, min=2, max=24, step=0.5,
-        description="Height (in)", style={"description_width": "100px"},
+        description="Height (in)", style={"description_width": "82px"},
+        layout=widgets.Layout(width="100%"),
         continuous_update=False,
     )
+
+    def _on_size(_):
+        S.set_figure_size(fig, fig_width.value, fig_height.value)
+        _refresh()
+
+    fig_width.observe(_on_size, names="value")
+    fig_height.observe(_on_size, names="value")
 
     # ── font ──────────────────────────────────────────────────────────────
     font_size = widgets.IntSlider(
         value=12, min=6, max=32, step=1,
-        description="Font size", style={"description_width": "100px"},
+        description="Font size", style={"description_width": "82px"},
+        layout=widgets.Layout(width="100%"),
         continuous_update=False,
     )
+
+    def _on_font(_):
+        S.set_font_size(fig, font_size.value)
+        _refresh()
+
+    font_size.observe(_on_font, names="value")
 
     # ── colors ────────────────────────────────────────────────────────────
     color_mode = widgets.ToggleButtons(
         options=["Palette", "Manual"],
         value="Palette",
-        description="Color mode:",
-        style={"button_width": "80px"},
+        description="Mode:",
+        style={"button_width": "72px"},
         layout=widgets.Layout(margin="0 0 4px 0"),
     )
 
-    # palette sub-section
     palette_select = widgets.Dropdown(
         options=palette_names(),
         description="Palette",
-        style={"description_width": "100px"},
+        style={"description_width": "58px"},
+        layout=widgets.Layout(width="100%"),
     )
     palette_preview = _build_palette_preview(palette_names()[0])
 
-    # manual sub-section — one ColorPicker per line, initialised to current color
     line_colors = S.get_line_colors(fig)
     line_labels = S.get_line_labels(fig)
     manual_pickers = [
         widgets.ColorPicker(
             value=color,
-            description=(label[:14] + "…" if len(label) > 14 else label),
-            style={"description_width": "90px"},
+            description=(label[:13] + "…" if len(label) > 13 else label),
+            style={"description_width": "82px"},
             concise=False,
-            layout=widgets.Layout(width="340px"),
+            layout=widgets.Layout(width="100%"),
         )
         for color, label in zip(line_colors, line_labels)
     ]
     manual_section = widgets.VBox(
         manual_pickers if manual_pickers
-        else [widgets.HTML("<i style='color:#888'>No lines found in figure.</i>")]
+        else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")]
     )
     manual_section.layout.display = "none"
 
+    palette_row = widgets.HBox(
+        [palette_select, palette_preview],
+        layout=widgets.Layout(width="100%"),
+    )
+
     bg_color = widgets.ColorPicker(
         value="#ffffff", description="Background",
-        style={"description_width": "100px"},
+        style={"description_width": "82px"},
         concise=False,
+        layout=widgets.Layout(width="100%"),
     )
+
+    def _apply_colors():
+        if color_mode.value == "Manual":
+            S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
+        else:
+            S.set_line_colors(fig, palette_select.value)
+        _refresh()
+
+    def _on_palette_change(change):
+        palette_row.children = (palette_select, _build_palette_preview(change["new"]))
+        _apply_colors()
+
+    def _on_color_mode_change(change):
+        if change["new"] == "Manual":
+            palette_row.layout.display = "none"
+            manual_section.layout.display = ""
+        else:
+            palette_row.layout.display = ""
+            manual_section.layout.display = "none"
+        _apply_colors()
+
+    def _on_bg_change(change):
+        if len(change["new"]) == 7:  # valid #rrggbb
+            S.set_background_color(fig, change["new"])
+            _refresh()
+
+    palette_select.observe(_on_palette_change, names="value")
+    color_mode.observe(_on_color_mode_change, names="value")
+    bg_color.observe(_on_bg_change, names="value")
+    for picker in manual_pickers:
+        picker.observe(lambda _: _apply_colors(), names="value")
 
     # ── legend ────────────────────────────────────────────────────────────
     legend_loc = widgets.Dropdown(
         options=S.LEGEND_LOCATIONS,
         value="best",
-        description="Legend loc", style={"description_width": "100px"},
+        description="Location",
+        style={"description_width": "68px"},
+        layout=widgets.Layout(width="100%"),
     )
 
+    def _on_legend(_):
+        S.set_legend_position(fig, legend_loc.value)
+        _refresh()
+
+    legend_loc.observe(_on_legend, names="value")
+
     # ── grid & spines ─────────────────────────────────────────────────────
-    grid_toggle = widgets.Checkbox(value=True, description="Show grid")
+    grid_toggle = widgets.Checkbox(value=False, description="Show grid")
     spine_style = widgets.ToggleButtons(
         options=S.SPINE_STYLES,
         value="box",
         description="Spines:",
-        style={"button_width": "100px"},
+        style={"button_width": "84px"},
     )
 
-    # ── colorblind recommendation ─────────────────────────────────────────
-    cb_recommend = widgets.Button(
-        description="Recommend colorblind-safe palette",
-        button_style="info",
-        layout=widgets.Layout(width="260px"),
-    )
-    recommend_out = widgets.Output()
-
-    # ── re-render output widget (only used in re-render mode) ─────────────
-    # Keeps the figure alive — plt.close() would destroy the canvas and break
-    # subsequent apply calls.
-    render_out = widgets.Output()
-
-    # ── apply button ──────────────────────────────────────────────────────
-    apply_btn = widgets.Button(
-        description="Apply",
-        button_style="success",
-        icon="check",
-        layout=widgets.Layout(width="120px"),
-    )
-    status = widgets.HTML(value="")
-
-    # ── callbacks ─────────────────────────────────────────────────────────
-
-    def _refresh():
-        if render_toggle.value == "re-render":
-            # savefig() always calls canvas.draw() internally, guaranteeing
-            # the latest artist state is rendered regardless of backend cache.
-            buf = io.BytesIO()
-            fig.savefig(buf, format="png", bbox_inches="tight", dpi=fig.dpi)
-            buf.seek(0)
-            with render_out:
-                render_out.clear_output(wait=True)
-                display(Image(buf.read()))
-        else:
-            S.redraw(fig)
-        status.value = "<span style='color:green'>✓ Applied</span>"
-
-    def _on_color_mode_change(change):
-        if change["new"] == "Manual":
-            palette_box.layout.display = "none"
-            manual_section.layout.display = ""
-        else:
-            palette_box.layout.display = ""
-            manual_section.layout.display = "none"
-
-    color_mode.observe(_on_color_mode_change, names="value")
-
-    def _on_apply(_):
-        S.set_figure_size(fig, fig_width.value, fig_height.value)
-        S.set_font_size(fig, font_size.value)
-        S.set_legend_position(fig, legend_loc.value)
-        if color_mode.value == "Manual":
-            S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
-        else:
-            S.set_line_colors(fig, palette_select.value)
-        S.set_background_color(fig, bg_color.value)
+    def _on_grid(_):
         S.set_grid(fig, grid_toggle.value)
+        _refresh()
+
+    def _on_spine(_):
         S.set_spine_style(fig, spine_style.value)
         _refresh()
 
-    def _on_palette_change(change):
-        nonlocal palette_preview
-        new_preview = _build_palette_preview(change["new"])
-        palette_box.children = (palette_select, new_preview)
+    grid_toggle.observe(_on_grid, names="value")
+    spine_style.observe(_on_spine, names="value")
+
+    # ── palette recommendation ─────────────────────────────────────────────
+    cb_recommend = widgets.Button(
+        description="Suggest colorblind-safe palette",
+        button_style="info",
+        layout=widgets.Layout(width="100%"),
+    )
+    recommend_out = widgets.Output()
 
     def _on_recommend(_):
         from .palettes import recommend
-        n = sum(len(ax.get_lines()) for ax in fig.axes) or 3
+        n = len(S.get_line_labels(fig)) or 3
         suggestions = recommend(n, colorblind_safe=True)
         with recommend_out:
             recommend_out.clear_output()
             for p in suggestions[:3]:
-                swatch = "  ".join(
-                    f"<span style='background:{c};padding:0 10px;border-radius:3px'>&nbsp;</span>"
+                swatch = "".join(
+                    f"<span style='background:{c};display:inline-block;"
+                    f"width:16px;height:16px;margin:1px;border-radius:2px'></span>"
                     for c in p["colors"][:n]
                 )
                 display(widgets.HTML(
                     f"<b>{p['name']}</b> — {p['description']}<br>{swatch}<br>"
                 ))
 
-    def _on_render_mode_change(change):
-        render_out.layout.display = "" if change["new"] == "re-render" else "none"
-
-    render_out.layout.display = "none" if render_mode == "in-place (ipympl)" else ""
-    render_toggle.observe(_on_render_mode_change, names="value")
-
-    apply_btn.on_click(_on_apply)
-    palette_select.observe(_on_palette_change, names="value")
     cb_recommend.on_click(_on_recommend)
 
-    # ── layout ────────────────────────────────────────────────────────────
-    palette_box = widgets.HBox([palette_select, palette_preview])
+    # ── responsive grid layout ─────────────────────────────────────────────
 
-    panel = widgets.VBox([
-        widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
-        render_toggle,
-        render_out,
-        widgets.HTML("<hr style='margin:4px 0'>"),
-        widgets.HTML("<b>Figure size</b>"),
-        fig_width, fig_height,
-        widgets.HTML("<b>Typography</b>"),
-        font_size,
-        widgets.HTML("<b>Colors</b>"),
-        color_mode,
-        palette_box,
-        manual_section,
-        bg_color,
-        widgets.HTML("<b>Legend</b>"),
-        legend_loc,
-        widgets.HTML("<b>Grid & Spines</b>"),
-        grid_toggle, spine_style,
-        widgets.HTML("<hr style='margin:4px 0'>"),
-        cb_recommend, recommend_out,
-        widgets.HBox([apply_btn, status]),
-    ], layout=widgets.Layout(padding="12px", width="380px",
-                              border="1px solid #ddd", border_radius="6px"))
+    def _section(title: str, *children) -> widgets.VBox:
+        return widgets.VBox(
+            [widgets.HTML(f"<b style='font-size:0.88em;color:#333'>{title}</b>"),
+             *children],
+            layout=widgets.Layout(
+                padding="8px 10px",
+                border="1px solid #e0e0e0",
+                border_radius="6px",
+            ),
+        )
+
+    grid = widgets.GridBox(
+        [
+            _section("Figure Size", fig_width, fig_height),
+            _section("Typography", font_size),
+            _section(
+                "Colors",
+                color_mode, palette_row, manual_section, bg_color,
+            ),
+            _section("Legend", legend_loc),
+            _section("Grid & Spines", grid_toggle, spine_style),
+            _section("Palette Suggestions", cb_recommend, recommend_out),
+        ],
+        layout=widgets.Layout(
+            grid_template_columns="repeat(auto-fill, minmax(280px, 1fr))",
+            grid_gap="8px",
+            width="100%",
+        ),
+    )
+
+    panel = widgets.VBox(
+        [
+            widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
+            render_out,
+            widgets.HTML("<hr style='margin:4px 0'>"),
+            grid,
+        ],
+        layout=widgets.Layout(width="100%", padding="10px"),
+    )
 
     display(panel)
 
@@ -244,8 +267,10 @@ def _build_palette_preview(name: str) -> widgets.HTML:
     from .palettes import get_palette
     colors = get_palette(name)
     swatches = "".join(
-        f"<span style='background:{c};display:inline-block;width:18px;height:18px;"
-        f"margin:1px;border-radius:3px;border:1px solid #ccc'></span>"
+        f"<span style='background:{c};display:inline-block;width:16px;height:16px;"
+        f"margin:1px;border-radius:2px;border:1px solid #ccc'></span>"
         for c in colors
     )
-    return widgets.HTML(value=f"<div style='margin-left:8px'>{swatches}</div>")
+    return widgets.HTML(
+        value=f"<div style='margin-left:6px;line-height:18px'>{swatches}</div>"
+    )

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -34,12 +34,27 @@ def studio(fig: Figure | None = None) -> None:
     # ── size toggle (fitted preview vs actual size) ───────────────────────
     size_toggle = widgets.ToggleButton(
         value=False,
-        description="Actual size",
+        description="Fitted",
         icon="expand",
         button_style="",
-        layout=widgets.Layout(width="120px", height="28px"),
-        tooltip="Toggle between fitted preview and actual rendered size",
+        layout=widgets.Layout(width="110px", height="28px"),
+        tooltip="Currently fitted — click to show at actual rendered size",
     )
+
+    def _on_size_toggle(change):
+        if change["new"]:
+            size_toggle.description = "Actual size"
+            size_toggle.icon = "compress"
+            size_toggle.button_style = "info"
+            size_toggle.tooltip = "Currently actual size — click to fit to panel"
+        else:
+            size_toggle.description = "Fitted"
+            size_toggle.icon = "expand"
+            size_toggle.button_style = ""
+            size_toggle.tooltip = "Currently fitted — click to show at actual rendered size"
+        _refresh()
+
+    size_toggle.observe(_on_size_toggle, names="value")
 
     # ── rendered output ───────────────────────────────────────────────────
     render_out = widgets.Output(
@@ -53,21 +68,26 @@ def studio(fig: Figure | None = None) -> None:
         img_b64 = base64.b64encode(buf.read()).decode()
 
         if size_toggle.value:
-            # actual size — let the image render at its natural pixel dimensions
-            img_style = "max-width:100%;height:auto;display:block"
+            # actual size — natural pixel dimensions; wrapper scrolls horizontally
+            # if the figure is wider than the notebook
+            img_style = "height:auto;display:block"
+            div_style = "overflow-x:auto;width:100%"
         else:
-            # fitted preview — cap height so the control panel stays visible
+            # fitted preview — capped height keeps the control panel in place
             img_style = (
                 f"max-height:{_PREVIEW_HEIGHT}px;width:auto;"
                 "max-width:100%;display:block;margin:0 auto"
             )
+            div_style = "width:100%"
 
-        img_html = f'<img src="data:image/png;base64,{img_b64}" style="{img_style}">'
+        img_html = (
+            f'<div style="{div_style}">'
+            f'<img src="data:image/png;base64,{img_b64}" style="{img_style}">'
+            f'</div>'
+        )
         with render_out:
             render_out.clear_output(wait=True)
             display(widgets.HTML(img_html))
-
-    size_toggle.observe(lambda _: _refresh(), names="value")
     _refresh()  # initial render
 
     # ── figure size ───────────────────────────────────────────────────────

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import base64
 import io
 
 import matplotlib.pyplot as plt
 import ipywidgets as widgets
-from IPython.display import display, Image
+from IPython.display import display
 from matplotlib.figure import Figure
 
 from . import style as S
 from .palettes import PALETTES, palette_names
+
+_PREVIEW_HEIGHT = 400  # px — fixed height for the fitted preview mode
 
 
 def studio(fig: Figure | None = None) -> None:
@@ -28,19 +31,43 @@ def studio(fig: Figure | None = None) -> None:
     if fig is None:
         fig = plt.gcf()
 
+    # ── size toggle (fitted preview vs actual size) ───────────────────────
+    size_toggle = widgets.ToggleButton(
+        value=False,
+        description="Actual size",
+        icon="expand",
+        button_style="",
+        layout=widgets.Layout(width="120px", height="28px"),
+        tooltip="Toggle between fitted preview and actual rendered size",
+    )
+
     # ── rendered output ───────────────────────────────────────────────────
     render_out = widgets.Output(
-        layout=widgets.Layout(width="100%", margin="0 0 8px 0")
+        layout=widgets.Layout(width="100%", margin="0 0 4px 0")
     )
 
     def _refresh(*_):
         buf = io.BytesIO()
         fig.savefig(buf, format="png", bbox_inches="tight", dpi=fig.dpi)
         buf.seek(0)
+        img_b64 = base64.b64encode(buf.read()).decode()
+
+        if size_toggle.value:
+            # actual size — let the image render at its natural pixel dimensions
+            img_style = "max-width:100%;height:auto;display:block"
+        else:
+            # fitted preview — cap height so the control panel stays visible
+            img_style = (
+                f"max-height:{_PREVIEW_HEIGHT}px;width:auto;"
+                "max-width:100%;display:block;margin:0 auto"
+            )
+
+        img_html = f'<img src="data:image/png;base64,{img_b64}" style="{img_style}">'
         with render_out:
             render_out.clear_output(wait=True)
-            display(Image(buf.read()))
+            display(widgets.HTML(img_html))
 
+    size_toggle.observe(lambda _: _refresh(), names="value")
     _refresh()  # initial render
 
     # ── figure size ───────────────────────────────────────────────────────
@@ -250,9 +277,22 @@ def studio(fig: Figure | None = None) -> None:
         ),
     )
 
-    panel = widgets.VBox(
+    header = widgets.HBox(
         [
             widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
+            size_toggle,
+        ],
+        layout=widgets.Layout(
+            justify_content="space-between",
+            align_items="center",
+            width="100%",
+            margin="0 0 6px 0",
+        ),
+    )
+
+    panel = widgets.VBox(
+        [
+            header,
             render_out,
             widgets.HTML("<hr style='margin:4px 0'>"),
             grid,

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -7,6 +7,8 @@ import ipywidgets as widgets
 from IPython.display import display
 from matplotlib.figure import Figure
 
+import matplotlib.colors as mcolors
+
 from . import style as S
 from .palettes import PALETTES, palette_names
 
@@ -58,12 +60,40 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
     )
 
     # ── colors ────────────────────────────────────────────────────────────
+    color_mode = widgets.ToggleButtons(
+        options=["Palette", "Manual"],
+        value="Palette",
+        description="Color mode:",
+        style={"button_width": "80px"},
+        layout=widgets.Layout(margin="0 0 4px 0"),
+    )
+
+    # palette sub-section
     palette_select = widgets.Dropdown(
         options=palette_names(),
         description="Palette",
         style={"description_width": "100px"},
     )
     palette_preview = _build_palette_preview(palette_names()[0])
+
+    # manual sub-section — one ColorPicker per line, initialised to current color
+    line_colors = S.get_line_colors(fig)
+    line_labels = S.get_line_labels(fig)
+    manual_pickers = [
+        widgets.ColorPicker(
+            value=color,
+            description=(label[:14] + "…" if len(label) > 14 else label),
+            style={"description_width": "90px"},
+            concise=False,
+            layout=widgets.Layout(width="340px"),
+        )
+        for color, label in zip(line_colors, line_labels)
+    ]
+    manual_section = widgets.VBox(
+        manual_pickers if manual_pickers
+        else [widgets.HTML("<i style='color:#888'>No lines found in figure.</i>")]
+    )
+    manual_section.layout.display = "none"
 
     bg_color = widgets.ColorPicker(
         value="#ffffff", description="Background",
@@ -120,11 +150,24 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
             S.redraw(fig)
         status.value = "<span style='color:green'>✓ Applied</span>"
 
+    def _on_color_mode_change(change):
+        if change["new"] == "Manual":
+            palette_box.layout.display = "none"
+            manual_section.layout.display = ""
+        else:
+            palette_box.layout.display = ""
+            manual_section.layout.display = "none"
+
+    color_mode.observe(_on_color_mode_change, names="value")
+
     def _on_apply(_):
         S.set_figure_size(fig, fig_width.value, fig_height.value)
         S.set_font_size(fig, font_size.value)
         S.set_legend_position(fig, legend_loc.value)
-        S.set_line_colors(fig, palette_select.value)
+        if color_mode.value == "Manual":
+            S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
+        else:
+            S.set_line_colors(fig, palette_select.value)
         S.set_background_color(fig, bg_color.value)
         S.set_grid(fig, grid_toggle.value)
         S.set_spine_style(fig, spine_style.value)
@@ -173,7 +216,9 @@ def studio(fig: Figure | None = None, *, render_mode: str = "in-place (ipympl)")
         widgets.HTML("<b>Typography</b>"),
         font_size,
         widgets.HTML("<b>Colors</b>"),
+        color_mode,
         palette_box,
+        manual_section,
         bg_color,
         widgets.HTML("<b>Legend</b>"),
         legend_loc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ dependencies = [
     "matplotlib>=3.5",
     "ipykernel>=6.0",
     "ipywidgets>=8.0",
-    "ipympl>=0.9",
 ]
 
 [project.optional-dependencies]
+ipympl = ["ipympl>=0.9"]
 dev = ["pytest", "jupyterlab"]
 
 [project.urls]

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -104,8 +104,47 @@ def test_get_line_labels_fallback():
     f, ax = plt.subplots()
     ax.plot([1, 2])  # no label → internal label starting with "_"
     labels = S.get_line_labels(f)
-    assert labels == ["Line 1"]
+    assert labels == []  # unlabelled artists are not in legend, so excluded
     plt.close(f)
+
+
+@pytest.fixture
+def scatter_fig():
+    f, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6], label="group A")
+    ax.scatter([1, 2, 3], [1, 2, 3], label="group B")
+    ax.legend()
+    yield f
+    plt.close(f)
+
+
+def test_scatter_palette_change(scatter_fig):
+    import matplotlib.colors as mcolors
+    S.set_line_colors(scatter_fig, "Okabe-Ito")
+    colors = S.get_line_colors(scatter_fig)
+    assert len(colors) == 2
+    assert colors[0].startswith("#")
+
+
+def test_scatter_manual_colors(scatter_fig):
+    import matplotlib.colors as mcolors
+    S.set_line_colors_manual(scatter_fig, ["#aabbcc", "#112233"])
+    colors = S.get_line_colors(scatter_fig)
+    assert mcolors.to_hex(mcolors.to_rgb(colors[0])) == "#aabbcc"
+    assert mcolors.to_hex(mcolors.to_rgb(colors[1])) == "#112233"
+
+
+def test_scatter_labels(scatter_fig):
+    labels = S.get_line_labels(scatter_fig)
+    assert labels == ["group A", "group B"]
+
+
+def test_scatter_legend_sync(scatter_fig):
+    import matplotlib.colors as mcolors
+    S.set_line_colors(scatter_fig, "Okabe-Ito")
+    # legend handles should have been synced
+    legend = scatter_fig.axes[0].get_legend()
+    assert legend is not None
 
 
 def test_studio_import():

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -62,5 +62,32 @@ def test_recommend_colorblind():
     assert all(len(p["colors"]) >= 3 for p in results)
 
 
+def test_set_line_colors_manual(fig):
+    S.set_line_colors_manual(fig, ["#ff0000"])
+    color = fig.axes[0].get_lines()[0].get_color()
+    import matplotlib.colors as mcolors
+    assert mcolors.to_hex(color).lower() == "#ff0000"
+
+
+def test_get_line_colors(fig):
+    S.set_line_colors(fig, "Okabe-Ito")
+    colors = S.get_line_colors(fig)
+    assert len(colors) == 1
+    assert colors[0].startswith("#")
+
+
+def test_get_line_labels(fig):
+    labels = S.get_line_labels(fig)
+    assert labels == ["line"]
+
+
+def test_get_line_labels_fallback():
+    f, ax = plt.subplots()
+    ax.plot([1, 2])  # no label → internal label starting with "_"
+    labels = S.get_line_labels(f)
+    assert labels == ["Line 1"]
+    plt.close(f)
+
+
 def test_studio_import():
     assert callable(mplstudio.studio)

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -62,6 +62,25 @@ def test_recommend_colorblind():
     assert all(len(p["colors"]) >= 3 for p in results)
 
 
+def test_legend_color_synced_after_palette_change(fig):
+    import matplotlib.colors as mcolors
+    S.set_line_colors(fig, "Okabe-Ito")
+    expected = mcolors.to_hex(fig.axes[0].get_lines()[0].get_color())
+    handle_color = mcolors.to_hex(
+        fig.axes[0].get_legend().legend_handles[0].get_color()
+    )
+    assert handle_color.lower() == expected.lower()
+
+
+def test_legend_color_synced_after_manual_change(fig):
+    import matplotlib.colors as mcolors
+    S.set_line_colors_manual(fig, ["#123456"])
+    handle_color = mcolors.to_hex(
+        fig.axes[0].get_legend().legend_handles[0].get_color()
+    )
+    assert handle_color.lower() == "#123456"
+
+
 def test_set_line_colors_manual(fig):
     S.set_line_colors_manual(fig, ["#ff0000"])
     color = fig.axes[0].get_lines()[0].get_color()


### PR DESCRIPTION
## Summary

Complete overhaul of the mplstudio panel UX, plus scatter plot support and several bug fixes.

## Changes

### Bug fixes
- **Scatter plot color support** (closes #4): introduced `_labeled_artists()`, `_get_artist_color()`, `_set_artist_color()` to handle both `Line2D` and `PathCollection` uniformly — palette changes and manual color pickers now work on scatter series
- **Legend handle sync** (closes #2): `_sync_legend_colors()` now iterates `legend.legend_handles` + `legend.get_texts()` directly instead of `ax.get_legend_handles_labels()`, which returns original axes artists rather than the legend's internal handle copies
- **Re-render mode palette not applying** (closes #2): replaced `display(fig)` with `fig.savefig()` → base64 `<img>` to guarantee a fresh render regardless of backend cache

### UX redesign (closes #5)
- Removed render mode toggle and in-place (ipympl) mode — always renders via `fig.savefig()`
- **Auto-refresh**: every widget observes its own value and calls `_refresh()` on change; no Apply button needed
- **Responsive layout**: `GridBox` with `repeat(auto-fill, minmax(280px, 1fr))` adapts to 2–4 columns based on notebook width
- Six named section cards: Figure Size, Typography, Colors, Legend, Grid & Spines, Palette Suggestions
- `ipympl` moved to optional dependency `[ipympl]`

### Fixed-height preview + size toggle
- Default **Fitted** mode: image capped at 400 px so control grid stays in a stable position when figure height changes
- **Actual size** toggle in the header: pure HTML/CSS rounded switch (`.slider.round` design) backed by a hidden `Checkbox` widget; `onchange` dispatches a synthetic event on the hidden checkbox input via `[data-model-id]` so ipywidgets syncs without any Jupyter-version-specific comm calls
- Both modes center the image with `text-align:center`; actual-size mode adds `overflow-x:auto` for wide figures

### Other
- `demo.ipynb`: removed `%matplotlib widget` requirement; added scatter demo cell; added `plt.close()` before `studio()` call
- 19 tests, all passing

## Known issues

- Horizontal scroll in actual-size mode may not work in all environments (#9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)