### PR TITLE
GUI panel: show parameter, opacity/axes/legend controls, overflow fix

### DIFF
--- a/mplstudio/__init__.py
+++ b/mplstudio/__init__.py
@@ -1,7 +1,7 @@
 """mplstudio — GUI styling tool for matplotlib figures in Jupyter."""
 
-from .widget import studio
+from .widget import studio, available_sections
 from .palettes import PALETTES, get_palette, recommend, palette_names
 
 __version__ = "0.1.0"
-__all__ = ["studio", "PALETTES", "get_palette", "recommend", "palette_names"]
+__all__ = ["studio", "available_sections", "PALETTES", "get_palette", "recommend", "palette_names"]

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -102,9 +102,11 @@ def set_legend_position(fig: Figure, location: str) -> None:
     for ax in fig.axes:
         legend = ax.get_legend()
         if legend:
-            handles, labels = ax.get_legend_handles_labels()
+            # Preserve user-edited label text when recreating the legend
+            handles = legend.legend_handles
+            labels = [t.get_text() for t in legend.get_texts()]
             if handles:
-                ax.legend(handles, labels, loc=location)
+                ax.legend(handles=handles, labels=labels, loc=location)
 
 
 def set_line_colors(fig: Figure, palette_name: str) -> None:
@@ -144,6 +146,69 @@ def get_line_labels(fig: Figure) -> list[str]:
         for ax in fig.axes
         for _, label in _labeled_artists(ax)
     ]
+
+
+def set_series_alpha(fig: Figure, alphas: list[float]) -> None:
+    """Set opacity per labeled series; call _refresh() after."""
+    idx = 0
+    for ax in fig.axes:
+        for artist, _ in _labeled_artists(ax):
+            if idx < len(alphas):
+                artist.set_alpha(float(alphas[idx]))
+            idx += 1
+
+
+def get_series_alpha(fig: Figure) -> list[float]:
+    return [
+        1.0 if artist.get_alpha() is None else float(artist.get_alpha())
+        for ax in fig.axes
+        for artist, _ in _labeled_artists(ax)
+    ]
+
+
+def set_title(fig: Figure, title: str, ax_idx: int = 0) -> None:
+    if ax_idx < len(fig.axes):
+        fig.axes[ax_idx].set_title(title)
+
+
+def set_xlabel(fig: Figure, label: str, ax_idx: int = 0) -> None:
+    if ax_idx < len(fig.axes):
+        fig.axes[ax_idx].set_xlabel(label)
+
+
+def set_ylabel(fig: Figure, label: str, ax_idx: int = 0) -> None:
+    if ax_idx < len(fig.axes):
+        fig.axes[ax_idx].set_ylabel(label)
+
+
+def set_xlim(fig: Figure, vmin: float, vmax: float, ax_idx: int = 0) -> None:
+    if ax_idx < len(fig.axes) and vmin < vmax:
+        fig.axes[ax_idx].set_xlim(vmin, vmax)
+
+
+def set_ylim(fig: Figure, vmin: float, vmax: float, ax_idx: int = 0) -> None:
+    if ax_idx < len(fig.axes) and vmin < vmax:
+        fig.axes[ax_idx].set_ylim(vmin, vmax)
+
+
+def set_legend_labels(fig: Figure, labels: list[str], ax_idx: int = 0) -> None:
+    """Edit legend entry text in-place without recreating the legend."""
+    if ax_idx >= len(fig.axes):
+        return
+    legend = fig.axes[ax_idx].get_legend()
+    if legend is None:
+        return
+    for text, new_label in zip(legend.get_texts(), labels):
+        text.set_text(new_label)
+
+
+def set_legend_bbox(fig: Figure, x: float, y: float, ax_idx: int = 0) -> None:
+    """Move the legend by adjusting bbox_to_anchor in-place."""
+    if ax_idx >= len(fig.axes):
+        return
+    legend = fig.axes[ax_idx].get_legend()
+    if legend:
+        legend.set_bbox_to_anchor((x, y))
 
 
 def set_background_color(fig: Figure, color: str) -> None:

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -547,12 +547,18 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
         avail_str = ", ".join(f"<code>{n}</code>" for n in sorted(_KNOWN_SECTIONS))
         sections.append(widgets.HTML(f"""
 <div style="padding:8px 10px;border:1px solid #f5a623;border-radius:6px;
-            background:#fffbf0;font-size:0.85em;color:#7a5300">
+            background:#fffbf0;font-size:0.85em;color:#7a5300;line-height:1.6">
+  <style>
+    .mplstudio-warn-{_mid[:8]} code {{
+      background:#f0d080;color:#3d2800;padding:1px 4px;
+      border-radius:3px;font-size:0.9em;
+    }}
+  </style>
+  <div class="mplstudio-warn-{_mid[:8]}">
   <b>Unknown section(s):</b> {names_str}<br>
-  <b>Available sections:</b> {avail_str}<br>
-  <a href="{_GITHUB_ISSUES}/new" target="_blank" style="color:#1a73e8">
-    Open a GitHub issue
-  </a> to request a new section.
+  <b>Available:</b> {avail_str}<br>
+  <a href="{_GITHUB_ISSUES}/new" target="_blank" style="color:#1a73e8">Open a GitHub issue</a> to request a new section.
+  </div>
 </div>
 """))
 

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -29,6 +29,11 @@ _KNOWN_SECTIONS = frozenset({
 _GITHUB_ISSUES = "https://github.com/symoon9/mplstudio/issues"
 
 
+def available_sections() -> list[str]:
+    """Return the sorted list of valid section names for the ``show`` parameter of :func:`studio`."""
+    return sorted(_KNOWN_SECTIONS)
+
+
 def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
     """Display the mplstudio control panel for *fig*.
 
@@ -135,6 +140,7 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
                 padding="8px 10px",
                 border="1px solid #e0e0e0",
                 border_radius="6px",
+                overflow="hidden",
             ),
         )
 
@@ -199,7 +205,7 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
         color_mode = widgets.ToggleButtons(
             options=["Palette", "Manual"], value="Palette",
             description="Mode:", style={"button_width": "72px"},
-            layout=widgets.Layout(margin="0 0 4px 0"),
+            layout=widgets.Layout(width="100%", margin="0 0 4px 0"),
         )
         palette_select = widgets.Dropdown(
             options=palette_names(), description="Palette",
@@ -274,6 +280,16 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
     if "alpha" in active:
         alphas = S.get_series_alpha(fig)
         a_labels = S.get_line_labels(fig)
+
+        init_global = (sum(alphas) / len(alphas)) if alphas else 1.0
+        global_alpha = widgets.FloatSlider(
+            value=init_global, min=0.0, max=1.0, step=0.05,
+            description="All series",
+            style={"description_width": "82px"},
+            layout=widgets.Layout(width="100%"),
+            continuous_update=False,
+        )
+
         alpha_sliders = [
             widgets.FloatSlider(
                 value=a, min=0.0, max=1.0, step=0.05,
@@ -285,18 +301,47 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
             for a, lbl in zip(alphas, a_labels)
         ]
 
-        def _on_alpha(_):
+        _alpha_busy = [False]  # guard: prevent global→per-series loop
+
+        def _on_global_alpha(change):
+            if _alpha_busy[0]:
+                return
+            _alpha_busy[0] = True
+            for s in alpha_sliders:
+                s.value = change["new"]
+            _alpha_busy[0] = False
+            S.set_series_alpha(fig, [change["new"]] * len(alpha_sliders))
+            _refresh()
+
+        def _on_per_alpha(_):
+            if _alpha_busy[0]:
+                return
             S.set_series_alpha(fig, [s.value for s in alpha_sliders])
             _refresh()
 
+        global_alpha.observe(_on_global_alpha, names="value")
         for s in alpha_sliders:
-            s.observe(_on_alpha, names="value")
+            s.observe(_on_per_alpha, names="value")
 
-        sections.append(_section(
-            "Opacity",
-            *(alpha_sliders if alpha_sliders
-              else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")])
-        ))
+        alpha_children: list[widgets.Widget] = [global_alpha]
+        if alpha_sliders:
+            per_box = widgets.VBox(
+                alpha_sliders,
+                layout=widgets.Layout(width="100%"),
+            )
+            per_acc = widgets.Accordion(
+                children=[per_box],
+                selected_index=None,
+                layout=widgets.Layout(width="100%"),
+            )
+            per_acc.set_title(0, "Per series")
+            alpha_children.append(per_acc)
+        else:
+            alpha_children.append(
+                widgets.HTML("<i style='color:#888'>No labeled series found.</i>")
+            )
+
+        sections.append(_section("Opacity", *alpha_children))
 
     # ══ Axes ══════════════════════════════════════════════════════════════
     if "axes" in active and fig.axes:
@@ -454,6 +499,7 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
         spine_style = widgets.ToggleButtons(
             options=S.SPINE_STYLES, value="box",
             description="Spines:", style={"button_width": "84px"},
+            layout=widgets.Layout(width="100%"),
         )
 
         def _on_grid(_):
@@ -498,14 +544,15 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
     # ══ Unknown section warning ════════════════════════════════════════════
     if unknown:
         names_str = ", ".join(f"<code>{n}</code>" for n in sorted(unknown))
+        avail_str = ", ".join(f"<code>{n}</code>" for n in sorted(_KNOWN_SECTIONS))
         sections.append(widgets.HTML(f"""
 <div style="padding:8px 10px;border:1px solid #f5a623;border-radius:6px;
             background:#fffbf0;font-size:0.85em;color:#7a5300">
   <b>Unknown section(s):</b> {names_str}<br>
-  This parameter is not supported yet.
+  <b>Available sections:</b> {avail_str}<br>
   <a href="{_GITHUB_ISSUES}/new" target="_blank" style="color:#1a73e8">
     Open a GitHub issue
-  </a> to request it.
+  </a> to request a new section.
 </div>
 """))
 
@@ -513,9 +560,10 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
     grid = widgets.GridBox(
         sections,
         layout=widgets.Layout(
-            grid_template_columns="repeat(auto-fill, minmax(280px, 1fr))",
+            grid_template_columns="repeat(auto-fill, minmax(260px, 1fr))",
             grid_gap="8px",
             width="100%",
+            overflow="hidden",
         ),
     )
 
@@ -529,7 +577,7 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
 
     display(widgets.VBox(
         [header, render_out, widgets.HTML("<hr style='margin:4px 0'>"), grid],
-        layout=widgets.Layout(width="100%", padding="10px"),
+        layout=widgets.Layout(width="100%", padding="10px", overflow="hidden"),
     ))
 
 

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -15,27 +15,46 @@ from .palettes import PALETTES, palette_names
 
 _PREVIEW_HEIGHT = 400  # px — fixed height for the fitted preview mode
 
+_KNOWN_SECTIONS = frozenset({
+    "figure_size",
+    "typography",
+    "colors",
+    "alpha",
+    "axes",
+    "legend",
+    "grid_spines",
+    "palette_suggestions",
+})
 
-def studio(fig: Figure | None = None) -> None:
+_GITHUB_ISSUES = "https://github.com/symoon9/mplstudio/issues"
+
+
+def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
     """Display the mplstudio control panel for *fig*.
-
-    The panel embeds a live-rendered image at the top and a responsive
-    grid of controls below. Every widget change auto-refreshes the figure
-    immediately — no Apply button needed.
 
     Parameters
     ----------
     fig:
         Target figure. Defaults to ``plt.gcf()``.
+    show:
+        List of section names to display. ``None`` (default) shows all sections.
+        Available sections: ``"figure_size"``, ``"typography"``, ``"colors"``,
+        ``"alpha"``, ``"axes"``, ``"legend"``, ``"grid_spines"``,
+        ``"palette_suggestions"``.
+        Unknown names produce a warning with a link to open a GitHub issue.
     """
     if fig is None:
         fig = plt.gcf()
 
+    if show is None:
+        active = _KNOWN_SECTIONS
+        unknown: frozenset[str] = frozenset()
+    else:
+        show_set = frozenset(show)
+        unknown = show_set - _KNOWN_SECTIONS
+        active = show_set & _KNOWN_SECTIONS
+
     # ── size toggle ───────────────────────────────────────────────────────
-    # A hidden Checkbox holds the Python state; the visual is a pure
-    # HTML/CSS toggle switch (user-supplied design) whose onchange handler
-    # dispatches a change event on the hidden checkbox input so ipywidgets
-    # picks it up without any Jupyter-version-specific comm calls.
     _size_cb = widgets.Checkbox(value=False, indent=False, description="")
     _size_cb.layout.display = "none"
     _mid = _size_cb.model_id
@@ -87,19 +106,14 @@ def studio(fig: Figure | None = None) -> None:
         img_b64 = base64.b64encode(buf.read()).decode()
 
         if _size_cb.value:
-            # Actual size: natural pixel dimensions.
-            # text-align:center centers the image when narrower than the
-            # panel; overflow-x:auto adds a scrollbar when wider.
             div_style = "text-align:center;overflow-x:auto;width:100%"
             img_style = "height:auto;display:inline-block;vertical-align:top"
         else:
-            # Fitted: cap height so the control panel doesn't jump.
             div_style = "text-align:center;width:100%"
             img_style = (
                 f"max-height:{_PREVIEW_HEIGHT}px;width:auto;"
                 "max-width:100%;display:inline-block;vertical-align:top"
             )
-
         img_html = (
             f'<div style="{div_style}">'
             f'<img src="data:image/png;base64,{img_b64}" style="{img_style}">'
@@ -110,185 +124,9 @@ def studio(fig: Figure | None = None) -> None:
             display(widgets.HTML(img_html))
 
     _size_cb.observe(lambda _: _refresh(), names="value")
-    _refresh()  # initial render
+    _refresh()
 
-    # ── figure size ───────────────────────────────────────────────────────
-    w_init, h_init = fig.get_size_inches()
-    fig_width = widgets.FloatSlider(
-        value=w_init, min=2, max=24, step=0.5,
-        description="Width (in)", style={"description_width": "82px"},
-        layout=widgets.Layout(width="100%"),
-        continuous_update=False,
-    )
-    fig_height = widgets.FloatSlider(
-        value=h_init, min=2, max=24, step=0.5,
-        description="Height (in)", style={"description_width": "82px"},
-        layout=widgets.Layout(width="100%"),
-        continuous_update=False,
-    )
-
-    def _on_size(_):
-        S.set_figure_size(fig, fig_width.value, fig_height.value)
-        _refresh()
-
-    fig_width.observe(_on_size, names="value")
-    fig_height.observe(_on_size, names="value")
-
-    # ── font ──────────────────────────────────────────────────────────────
-    font_size = widgets.IntSlider(
-        value=12, min=6, max=32, step=1,
-        description="Font size", style={"description_width": "82px"},
-        layout=widgets.Layout(width="100%"),
-        continuous_update=False,
-    )
-
-    def _on_font(_):
-        S.set_font_size(fig, font_size.value)
-        _refresh()
-
-    font_size.observe(_on_font, names="value")
-
-    # ── colors ────────────────────────────────────────────────────────────
-    color_mode = widgets.ToggleButtons(
-        options=["Palette", "Manual"],
-        value="Palette",
-        description="Mode:",
-        style={"button_width": "72px"},
-        layout=widgets.Layout(margin="0 0 4px 0"),
-    )
-
-    palette_select = widgets.Dropdown(
-        options=palette_names(),
-        description="Palette",
-        style={"description_width": "58px"},
-        layout=widgets.Layout(width="100%"),
-    )
-    palette_preview = _build_palette_preview(palette_names()[0])
-
-    line_colors = S.get_line_colors(fig)
-    line_labels = S.get_line_labels(fig)
-    manual_pickers = [
-        widgets.ColorPicker(
-            value=color,
-            description=(label[:13] + "…" if len(label) > 13 else label),
-            style={"description_width": "82px"},
-            concise=False,
-            layout=widgets.Layout(width="100%"),
-        )
-        for color, label in zip(line_colors, line_labels)
-    ]
-    manual_section = widgets.VBox(
-        manual_pickers if manual_pickers
-        else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")]
-    )
-    manual_section.layout.display = "none"
-
-    palette_row = widgets.HBox(
-        [palette_select, palette_preview],
-        layout=widgets.Layout(width="100%"),
-    )
-
-    bg_color = widgets.ColorPicker(
-        value="#ffffff", description="Background",
-        style={"description_width": "82px"},
-        concise=False,
-        layout=widgets.Layout(width="100%"),
-    )
-
-    def _apply_colors():
-        if color_mode.value == "Manual":
-            S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
-        else:
-            S.set_line_colors(fig, palette_select.value)
-        _refresh()
-
-    def _on_palette_change(change):
-        palette_row.children = (palette_select, _build_palette_preview(change["new"]))
-        _apply_colors()
-
-    def _on_color_mode_change(change):
-        if change["new"] == "Manual":
-            palette_row.layout.display = "none"
-            manual_section.layout.display = ""
-        else:
-            palette_row.layout.display = ""
-            manual_section.layout.display = "none"
-        _apply_colors()
-
-    def _on_bg_change(change):
-        if len(change["new"]) == 7:  # valid #rrggbb
-            S.set_background_color(fig, change["new"])
-            _refresh()
-
-    palette_select.observe(_on_palette_change, names="value")
-    color_mode.observe(_on_color_mode_change, names="value")
-    bg_color.observe(_on_bg_change, names="value")
-    for picker in manual_pickers:
-        picker.observe(lambda _: _apply_colors(), names="value")
-
-    # ── legend ────────────────────────────────────────────────────────────
-    legend_loc = widgets.Dropdown(
-        options=S.LEGEND_LOCATIONS,
-        value="best",
-        description="Location",
-        style={"description_width": "68px"},
-        layout=widgets.Layout(width="100%"),
-    )
-
-    def _on_legend(_):
-        S.set_legend_position(fig, legend_loc.value)
-        _refresh()
-
-    legend_loc.observe(_on_legend, names="value")
-
-    # ── grid & spines ─────────────────────────────────────────────────────
-    grid_toggle = widgets.Checkbox(value=False, description="Show grid")
-    spine_style = widgets.ToggleButtons(
-        options=S.SPINE_STYLES,
-        value="box",
-        description="Spines:",
-        style={"button_width": "84px"},
-    )
-
-    def _on_grid(_):
-        S.set_grid(fig, grid_toggle.value)
-        _refresh()
-
-    def _on_spine(_):
-        S.set_spine_style(fig, spine_style.value)
-        _refresh()
-
-    grid_toggle.observe(_on_grid, names="value")
-    spine_style.observe(_on_spine, names="value")
-
-    # ── palette recommendation ─────────────────────────────────────────────
-    cb_recommend = widgets.Button(
-        description="Suggest colorblind-safe palette",
-        button_style="info",
-        layout=widgets.Layout(width="100%"),
-    )
-    recommend_out = widgets.Output()
-
-    def _on_recommend(_):
-        from .palettes import recommend
-        n = len(S.get_line_labels(fig)) or 3
-        suggestions = recommend(n, colorblind_safe=True)
-        with recommend_out:
-            recommend_out.clear_output()
-            for p in suggestions[:3]:
-                swatch = "".join(
-                    f"<span style='background:{c};display:inline-block;"
-                    f"width:16px;height:16px;margin:1px;border-radius:2px'></span>"
-                    for c in p["colors"][:n]
-                )
-                display(widgets.HTML(
-                    f"<b>{p['name']}</b> — {p['description']}<br>{swatch}<br>"
-                ))
-
-    cb_recommend.on_click(_on_recommend)
-
-    # ── responsive grid layout ─────────────────────────────────────────────
-
+    # ── section builder ───────────────────────────────────────────────────
     def _section(title: str, *children) -> widgets.VBox:
         return widgets.VBox(
             [widgets.HTML(f"<b style='font-size:0.88em;color:#333'>{title}</b>"),
@@ -300,18 +138,380 @@ def studio(fig: Figure | None = None) -> None:
             ),
         )
 
+    # ── helper: FloatText pair (min/max) ──────────────────────────────────
+    def _range_row(label: str, lo: float, hi: float,
+                   on_change) -> tuple[widgets.HBox, widgets.FloatText, widgets.FloatText]:
+        w_lo = widgets.FloatText(
+            value=round(lo, 4), description=f"{label} min",
+            style={"description_width": "50px"},
+            layout=widgets.Layout(width="160px"),
+        )
+        w_hi = widgets.FloatText(
+            value=round(hi, 4), description="max",
+            style={"description_width": "30px"},
+            layout=widgets.Layout(width="130px"),
+        )
+        w_lo.observe(on_change, names="value")
+        w_hi.observe(on_change, names="value")
+        return widgets.HBox([w_lo, w_hi]), w_lo, w_hi
+
+    sections: list[widgets.Widget] = []
+
+    # ══ Figure Size ═══════════════════════════════════════════════════════
+    if "figure_size" in active:
+        w_init, h_init = fig.get_size_inches()
+        fig_width = widgets.FloatSlider(
+            value=w_init, min=2, max=25, step=0.5,
+            description="Width (in)", style={"description_width": "82px"},
+            layout=widgets.Layout(width="100%"), continuous_update=False,
+        )
+        fig_height = widgets.FloatSlider(
+            value=h_init, min=2, max=25, step=0.5,
+            description="Height (in)", style={"description_width": "82px"},
+            layout=widgets.Layout(width="100%"), continuous_update=False,
+        )
+
+        def _on_size(_):
+            S.set_figure_size(fig, fig_width.value, fig_height.value)
+            _refresh()
+
+        fig_width.observe(_on_size, names="value")
+        fig_height.observe(_on_size, names="value")
+        sections.append(_section("Figure Size", fig_width, fig_height))
+
+    # ══ Typography ════════════════════════════════════════════════════════
+    if "typography" in active:
+        font_size = widgets.IntSlider(
+            value=12, min=6, max=32, step=1,
+            description="Font size", style={"description_width": "82px"},
+            layout=widgets.Layout(width="100%"), continuous_update=False,
+        )
+
+        def _on_font(_):
+            S.set_font_size(fig, font_size.value)
+            _refresh()
+
+        font_size.observe(_on_font, names="value")
+        sections.append(_section("Typography", font_size))
+
+    # ══ Colors ════════════════════════════════════════════════════════════
+    if "colors" in active:
+        color_mode = widgets.ToggleButtons(
+            options=["Palette", "Manual"], value="Palette",
+            description="Mode:", style={"button_width": "72px"},
+            layout=widgets.Layout(margin="0 0 4px 0"),
+        )
+        palette_select = widgets.Dropdown(
+            options=palette_names(), description="Palette",
+            style={"description_width": "58px"},
+            layout=widgets.Layout(width="100%"),
+        )
+        palette_preview = _build_palette_preview(palette_names()[0])
+        palette_row = widgets.HBox(
+            [palette_select, palette_preview],
+            layout=widgets.Layout(width="100%"),
+        )
+
+        line_colors = S.get_line_colors(fig)
+        line_labels = S.get_line_labels(fig)
+        manual_pickers = [
+            widgets.ColorPicker(
+                value=color,
+                description=(label[:13] + "…" if len(label) > 13 else label),
+                style={"description_width": "82px"}, concise=False,
+                layout=widgets.Layout(width="100%"),
+            )
+            for color, label in zip(line_colors, line_labels)
+        ]
+        manual_section = widgets.VBox(
+            manual_pickers if manual_pickers
+            else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")]
+        )
+        manual_section.layout.display = "none"
+
+        bg_color = widgets.ColorPicker(
+            value="#ffffff", description="Background",
+            style={"description_width": "82px"}, concise=False,
+            layout=widgets.Layout(width="100%"),
+        )
+
+        def _apply_colors():
+            if color_mode.value == "Manual":
+                S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
+            else:
+                S.set_line_colors(fig, palette_select.value)
+            _refresh()
+
+        def _on_palette_change(change):
+            palette_row.children = (palette_select, _build_palette_preview(change["new"]))
+            _apply_colors()
+
+        def _on_color_mode_change(change):
+            if change["new"] == "Manual":
+                palette_row.layout.display = "none"
+                manual_section.layout.display = ""
+            else:
+                palette_row.layout.display = ""
+                manual_section.layout.display = "none"
+            _apply_colors()
+
+        def _on_bg_change(change):
+            if len(change["new"]) == 7:
+                S.set_background_color(fig, change["new"])
+                _refresh()
+
+        palette_select.observe(_on_palette_change, names="value")
+        color_mode.observe(_on_color_mode_change, names="value")
+        bg_color.observe(_on_bg_change, names="value")
+        for picker in manual_pickers:
+            picker.observe(lambda _: _apply_colors(), names="value")
+
+        sections.append(_section(
+            "Colors", color_mode, palette_row, manual_section, bg_color,
+        ))
+
+    # ══ Opacity (Alpha) ═══════════════════════════════════════════════════
+    if "alpha" in active:
+        alphas = S.get_series_alpha(fig)
+        a_labels = S.get_line_labels(fig)
+        alpha_sliders = [
+            widgets.FloatSlider(
+                value=a, min=0.0, max=1.0, step=0.05,
+                description=(lbl[:13] + "…" if len(lbl) > 13 else lbl),
+                style={"description_width": "82px"},
+                layout=widgets.Layout(width="100%"),
+                continuous_update=False,
+            )
+            for a, lbl in zip(alphas, a_labels)
+        ]
+
+        def _on_alpha(_):
+            S.set_series_alpha(fig, [s.value for s in alpha_sliders])
+            _refresh()
+
+        for s in alpha_sliders:
+            s.observe(_on_alpha, names="value")
+
+        sections.append(_section(
+            "Opacity",
+            *(alpha_sliders if alpha_sliders
+              else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")])
+        ))
+
+    # ══ Axes ══════════════════════════════════════════════════════════════
+    if "axes" in active and fig.axes:
+        ax_idx = [0]  # mutable ref so inner callbacks can update it
+
+        ax_selector = None
+        if len(fig.axes) > 1:
+            ax_selector = widgets.Dropdown(
+                options=[(f"Axes {i}", i) for i in range(len(fig.axes))],
+                value=0, description="Axes:",
+                style={"description_width": "40px"},
+                layout=widgets.Layout(width="100%"),
+            )
+
+        def _cur_ax():
+            return fig.axes[ax_idx[0]]
+
+        title_input = widgets.Text(
+            value=_cur_ax().get_title(), description="Title",
+            style={"description_width": "50px"},
+            layout=widgets.Layout(width="100%"),
+            continuous_update=False,
+        )
+        xlabel_input = widgets.Text(
+            value=_cur_ax().get_xlabel(), description="X label",
+            style={"description_width": "50px"},
+            layout=widgets.Layout(width="100%"),
+            continuous_update=False,
+        )
+        ylabel_input = widgets.Text(
+            value=_cur_ax().get_ylabel(), description="Y label",
+            style={"description_width": "50px"},
+            layout=widgets.Layout(width="100%"),
+            continuous_update=False,
+        )
+
+        xlim = _cur_ax().get_xlim()
+        ylim = _cur_ax().get_ylim()
+
+        def _on_xlim(_):
+            S.set_xlim(fig, xlim_lo.value, xlim_hi.value, ax_idx[0])
+            _refresh()
+
+        def _on_ylim(_):
+            S.set_ylim(fig, ylim_lo.value, ylim_hi.value, ax_idx[0])
+            _refresh()
+
+        xlim_row, xlim_lo, xlim_hi = _range_row("X lim", xlim[0], xlim[1], _on_xlim)
+        ylim_row, ylim_lo, ylim_hi = _range_row("Y lim", ylim[0], ylim[1], _on_ylim)
+
+        def _on_title(_):
+            S.set_title(fig, title_input.value, ax_idx[0])
+            _refresh()
+
+        def _on_xlabel(_):
+            S.set_xlabel(fig, xlabel_input.value, ax_idx[0])
+            _refresh()
+
+        def _on_ylabel(_):
+            S.set_ylabel(fig, ylabel_input.value, ax_idx[0])
+            _refresh()
+
+        title_input.observe(_on_title, names="value")
+        xlabel_input.observe(_on_xlabel, names="value")
+        ylabel_input.observe(_on_ylabel, names="value")
+
+        def _on_ax_select(change):
+            ax_idx[0] = change["new"]
+            ax = fig.axes[ax_idx[0]]
+            title_input.value = ax.get_title()
+            xlabel_input.value = ax.get_xlabel()
+            ylabel_input.value = ax.get_ylabel()
+            xl = ax.get_xlim()
+            yl = ax.get_ylim()
+            xlim_lo.value, xlim_hi.value = round(xl[0], 4), round(xl[1], 4)
+            ylim_lo.value, ylim_hi.value = round(yl[0], 4), round(yl[1], 4)
+
+        if ax_selector:
+            ax_selector.observe(_on_ax_select, names="value")
+
+        axes_children = (
+            ([ax_selector] if ax_selector else [])
+            + [title_input, xlabel_input, ylabel_input, xlim_row, ylim_row]
+        )
+        sections.append(_section("Axes", *axes_children))
+
+    # ══ Legend ════════════════════════════════════════════════════════════
+    if "legend" in active:
+        legend_loc = widgets.Dropdown(
+            options=S.LEGEND_LOCATIONS, value="best",
+            description="Location", style={"description_width": "68px"},
+            layout=widgets.Layout(width="100%"),
+        )
+
+        def _on_legend_loc(_):
+            S.set_legend_position(fig, legend_loc.value)
+            _refresh()
+
+        legend_loc.observe(_on_legend_loc, names="value")
+
+        # ── legend label editing ──────────────────────────────────────────
+        leg0 = fig.axes[0].get_legend() if fig.axes else None
+        leg_texts = [t.get_text() for t in leg0.get_texts()] if leg0 else []
+        name_inputs = [
+            widgets.Text(
+                value=txt,
+                description=(txt[:12] + "…:" if len(txt) > 12 else f"{txt}:"),
+                style={"description_width": "78px"},
+                layout=widgets.Layout(width="100%"),
+                continuous_update=False,
+            )
+            for txt in leg_texts
+        ]
+
+        def _on_legend_name(_):
+            S.set_legend_labels(fig, [inp.value for inp in name_inputs])
+            _refresh()
+
+        for inp in name_inputs:
+            inp.observe(_on_legend_name, names="value")
+
+        # ── bbox fine control ─────────────────────────────────────────────
+        bbox_header = widgets.HTML(
+            "<span style='font-size:0.82em;color:#666'>BBox position (x, y)</span>"
+        )
+        bbox_x = widgets.FloatSlider(
+            value=1.02, min=0.0, max=1.5, step=0.01,
+            description="x", style={"description_width": "20px"},
+            layout=widgets.Layout(width="100%"), continuous_update=False,
+        )
+        bbox_y = widgets.FloatSlider(
+            value=1.0, min=0.0, max=1.5, step=0.01,
+            description="y", style={"description_width": "20px"},
+            layout=widgets.Layout(width="100%"), continuous_update=False,
+        )
+
+        def _on_bbox(_):
+            S.set_legend_bbox(fig, bbox_x.value, bbox_y.value)
+            _refresh()
+
+        bbox_x.observe(_on_bbox, names="value")
+        bbox_y.observe(_on_bbox, names="value")
+
+        legend_children = (
+            [legend_loc]
+            + (name_inputs if name_inputs
+               else [widgets.HTML("<i style='color:#888;font-size:0.85em'>No legend entries.</i>")])
+            + [bbox_header, bbox_x, bbox_y]
+        )
+        sections.append(_section("Legend", *legend_children))
+
+    # ══ Grid & Spines ═════════════════════════════════════════════════════
+    if "grid_spines" in active:
+        grid_toggle = widgets.Checkbox(value=False, description="Show grid")
+        spine_style = widgets.ToggleButtons(
+            options=S.SPINE_STYLES, value="box",
+            description="Spines:", style={"button_width": "84px"},
+        )
+
+        def _on_grid(_):
+            S.set_grid(fig, grid_toggle.value)
+            _refresh()
+
+        def _on_spine(_):
+            S.set_spine_style(fig, spine_style.value)
+            _refresh()
+
+        grid_toggle.observe(_on_grid, names="value")
+        spine_style.observe(_on_spine, names="value")
+        sections.append(_section("Grid & Spines", grid_toggle, spine_style))
+
+    # ══ Palette Suggestions ═══════════════════════════════════════════════
+    if "palette_suggestions" in active:
+        cb_recommend = widgets.Button(
+            description="Suggest colorblind-safe palette",
+            button_style="info", layout=widgets.Layout(width="100%"),
+        )
+        recommend_out = widgets.Output()
+
+        def _on_recommend(_):
+            from .palettes import recommend
+            n = len(S.get_line_labels(fig)) or 3
+            suggestions = recommend(n, colorblind_safe=True)
+            with recommend_out:
+                recommend_out.clear_output()
+                for p in suggestions[:3]:
+                    swatch = "".join(
+                        f"<span style='background:{c};display:inline-block;"
+                        f"width:16px;height:16px;margin:1px;border-radius:2px'></span>"
+                        for c in p["colors"][:n]
+                    )
+                    display(widgets.HTML(
+                        f"<b>{p['name']}</b> — {p['description']}<br>{swatch}<br>"
+                    ))
+
+        cb_recommend.on_click(_on_recommend)
+        sections.append(_section("Palette Suggestions", cb_recommend, recommend_out))
+
+    # ══ Unknown section warning ════════════════════════════════════════════
+    if unknown:
+        names_str = ", ".join(f"<code>{n}</code>" for n in sorted(unknown))
+        sections.append(widgets.HTML(f"""
+<div style="padding:8px 10px;border:1px solid #f5a623;border-radius:6px;
+            background:#fffbf0;font-size:0.85em;color:#7a5300">
+  <b>Unknown section(s):</b> {names_str}<br>
+  This parameter is not supported yet.
+  <a href="{_GITHUB_ISSUES}/new" target="_blank" style="color:#1a73e8">
+    Open a GitHub issue
+  </a> to request it.
+</div>
+"""))
+
+    # ── layout ────────────────────────────────────────────────────────────
     grid = widgets.GridBox(
-        [
-            _section("Figure Size", fig_width, fig_height),
-            _section("Typography", font_size),
-            _section(
-                "Colors",
-                color_mode, palette_row, manual_section, bg_color,
-            ),
-            _section("Legend", legend_loc),
-            _section("Grid & Spines", grid_toggle, spine_style),
-            _section("Palette Suggestions", cb_recommend, recommend_out),
-        ],
+        sections,
         layout=widgets.Layout(
             grid_template_columns="repeat(auto-fill, minmax(280px, 1fr))",
             grid_gap="8px",
@@ -320,29 +520,17 @@ def studio(fig: Figure | None = None) -> None:
     )
 
     header = widgets.HBox(
-        [
-            widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"),
-            toggle_row,
-        ],
+        [widgets.HTML("<b style='font-size:1.1em'>mplstudio</b>"), toggle_row],
         layout=widgets.Layout(
-            justify_content="space-between",
-            align_items="center",
-            width="100%",
-            margin="0 0 6px 0",
+            justify_content="space-between", align_items="center",
+            width="100%", margin="0 0 6px 0",
         ),
     )
 
-    panel = widgets.VBox(
-        [
-            header,
-            render_out,
-            widgets.HTML("<hr style='margin:4px 0'>"),
-            grid,
-        ],
+    display(widgets.VBox(
+        [header, render_out, widgets.HTML("<hr style='margin:4px 0'>"), grid],
         layout=widgets.Layout(width="100%", padding="10px"),
-    )
-
-    display(panel)
+    ))
 
 
 def _build_palette_preview(name: str) -> widgets.HTML:

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -547,7 +547,7 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
         avail_str = ", ".join(f"<code>{n}</code>" for n in sorted(_KNOWN_SECTIONS))
         sections.append(widgets.HTML(f"""
 <div style="padding:8px 10px;border:1px solid #f5a623;border-radius:6px;
-            background:#fffbf0;font-size:0.85em;color:#7a5300;line-height:1.6">
+            background:#fffbf0;font-size:1em;color:#7a5300;line-height:1.6">
   <style>
     .mplstudio-warn-{_mid[:8]} code {{
       background:#f0d080;color:#3d2800;padding:1px 4px;

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -151,6 +151,15 @@ def test_studio_import():
     assert callable(mplstudio.studio)
 
 
+def test_available_sections():
+    sections = mplstudio.available_sections()
+    assert isinstance(sections, list)
+    assert "colors" in sections
+    assert "alpha" in sections
+    assert "axes" in sections
+    assert sections == sorted(sections)
+
+
 def test_set_series_alpha(fig):
     S.set_series_alpha(fig, [0.4])
     artist = fig.axes[0].get_lines()[0]

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -149,3 +149,68 @@ def test_scatter_legend_sync(scatter_fig):
 
 def test_studio_import():
     assert callable(mplstudio.studio)
+
+
+def test_set_series_alpha(fig):
+    S.set_series_alpha(fig, [0.4])
+    artist = fig.axes[0].get_lines()[0]
+    assert artist.get_alpha() == pytest.approx(0.4)
+
+
+def test_get_series_alpha(fig):
+    alphas = S.get_series_alpha(fig)
+    assert len(alphas) == 1
+    assert alphas[0] == pytest.approx(1.0)
+
+
+def test_set_series_alpha_updates_value(fig):
+    S.set_series_alpha(fig, [0.25])
+    alphas = S.get_series_alpha(fig)
+    assert alphas[0] == pytest.approx(0.25)
+
+
+def test_set_title(fig):
+    S.set_title(fig, "My Title")
+    assert fig.axes[0].get_title() == "My Title"
+
+
+def test_set_xlabel(fig):
+    S.set_xlabel(fig, "X axis")
+    assert fig.axes[0].get_xlabel() == "X axis"
+
+
+def test_set_ylabel(fig):
+    S.set_ylabel(fig, "Y axis")
+    assert fig.axes[0].get_ylabel() == "Y axis"
+
+
+def test_set_xlim(fig):
+    S.set_xlim(fig, 0.5, 2.5)
+    lo, hi = fig.axes[0].get_xlim()
+    assert lo == pytest.approx(0.5)
+    assert hi == pytest.approx(2.5)
+
+
+def test_set_xlim_ignored_when_inverted(fig):
+    before = fig.axes[0].get_xlim()
+    S.set_xlim(fig, 5.0, 1.0)  # vmin > vmax → no-op
+    assert fig.axes[0].get_xlim() == before
+
+
+def test_set_ylim(fig):
+    S.set_ylim(fig, -2.0, 2.0)
+    lo, hi = fig.axes[0].get_ylim()
+    assert lo == pytest.approx(-2.0)
+    assert hi == pytest.approx(2.0)
+
+
+def test_set_legend_labels(fig):
+    S.set_legend_labels(fig, ["renamed"])
+    texts = [t.get_text() for t in fig.axes[0].get_legend().get_texts()]
+    assert texts == ["renamed"]
+
+
+def test_set_legend_bbox(fig):
+    S.set_legend_bbox(fig, 0.8, 0.9)
+    legend = fig.axes[0].get_legend()
+    assert legend is not None  # smoke test — bbox_to_anchor set without error


### PR DESCRIPTION
## Summary

- **`show` parameter** — `studio(fig, show=[...])` controls which sections are rendered; unknown section names display an inline warning listing all available sections and linking to GitHub Issues
- **New style API functions** — `set_series_alpha`, `get_series_alpha`, `set_title`, `set_xlabel`, `set_ylabel`, `set_xlim`, `set_ylim`, `set_legend_labels`, `set_legend_bbox`; `set_legend_position` now preserves user-edited label text
- **Opacity section** — global "All series" slider + collapsible per-series accordion (collapsed by default); update guard prevents callback loop
- **Axes section** — title / xlabel / ylabel text inputs, xlim / ylim float-text pairs; optional axis selector for multi-axes figures
- **Legend section** — per-entry name editing, bbox x/y fine-tune sliders (in addition to location dropdown)
- **`available_sections()` API** — top-level function returning sorted list of valid `show=` values
- **Overflow fix** — `overflow: hidden` on sections, GridBox, outer VBox; `width: 100%` on ToggleButtons; grid minmax 280 → 260 px
- **Preview** — fixed-height (400 px) with iOS-style toggle for actual size
- **4 new trendy palettes** — Nord, Catppuccin Latte, Dracula, Tokyo Night
- 31 tests, all passing

## Test plan

- [ ] `studio(fig)` renders all 8 sections with no errors
- [ ] `studio(fig, show=["colors", "alpha"])` shows only those two sections
- [ ] `studio(fig, show=["colors", "unknown_thing"])` shows warning with available list
- [ ] `mplstudio.available_sections()` returns the full sorted list
- [ ] Opacity global slider sets all series; per-series accordion expands and adjusts individually
- [ ] Axes section updates title / labels / limits live
- [ ] Legend name inputs rename entries; bbox sliders move legend
- [ ] No horizontal scrollbar on any section (manual colors, spine toggle, etc.)
- [ ] `pytest tests/` → 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)