### PR TITLE
Smart palette, continuous colormap support, swatch layout fix

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -182,44 +182,111 @@
   {
    "cell_type": "markdown",
    "id": "85ed5069",
-   "source": "## 5. Heatmap (continuous colormap)\n\nmplstudio auto-detects continuous data (`imshow`, `pcolormesh`) and shows a **colormap picker** with a gradient preview instead of the categorical palette controls.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 5. Heatmap (continuous colormap)\n",
+    "\n",
+    "mplstudio auto-detects continuous data (`imshow`, `pcolormesh`) and shows a **colormap picker** with a gradient preview instead of the categorical palette controls."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "dc3f00ac",
-   "source": "import numpy as np\nimport matplotlib.pyplot as plt\nimport mplstudio\n\n# 2-D heatmap via imshow\nrng = np.random.default_rng(42)\ndata = rng.standard_normal((12, 12))\n\nfig5, ax5 = plt.subplots()\nim = ax5.imshow(data, cmap='viridis')\nfig5.colorbar(im, ax=ax5, label='value')\nax5.set_title('Random heatmap')\nplt.close()\n\n# Colors section shows \"Detected: continuous\" → colormap picker with gradient preview\nmplstudio.studio(fig5)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "dc3f00ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import mplstudio\n",
+    "\n",
+    "# 2-D heatmap via imshow\n",
+    "rng = np.random.default_rng(42)\n",
+    "data = rng.standard_normal((12, 12))\n",
+    "\n",
+    "fig5, ax5 = plt.subplots()\n",
+    "im = ax5.imshow(data, cmap='viridis')\n",
+    "fig5.colorbar(im, ax=ax5, label='value')\n",
+    "ax5.set_title('Random heatmap')\n",
+    "plt.close()\n",
+    "\n",
+    "# Colors section shows \"Detected: continuous\" → colormap picker with gradient preview\n",
+    "mplstudio.studio(fig5)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "f19d7a37",
-   "source": "## 6. pcolormesh (continuous + diverging)\n\n`pcolormesh` is common for 2-D field data (e.g. atmospheric, oceanographic). mplstudio detects the scalar-mapped mesh and exposes the same colormap controls.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 6. pcolormesh (continuous + diverging)\n",
+    "\n",
+    "`pcolormesh` is common for 2-D field data (e.g. atmospheric, oceanographic). mplstudio detects the scalar-mapped mesh and exposes the same colormap controls."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "48c0fe14",
-   "source": "x = np.linspace(-np.pi, np.pi, 60)\ny = np.linspace(-np.pi, np.pi, 60)\nX, Y = np.meshgrid(x, y)\nZ = np.sin(X) * np.cos(Y)   # diverging data centred around 0\n\nfig6, ax6 = plt.subplots()\npc = ax6.pcolormesh(X, Y, Z, cmap='coolwarm', shading='auto')\nfig6.colorbar(pc, ax=ax6, label='sin(x)·cos(y)')\nax6.set_title('sin(x)·cos(y)')\nax6.set_xlabel('x')\nax6.set_ylabel('y')\nplt.close()\n\n# Switch to \"Diverging\" tab in the colormap picker to try RdBu_r, PiYG, seismic…\nmplstudio.studio(fig6)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "48c0fe14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(-np.pi, np.pi, 60)\n",
+    "y = np.linspace(-np.pi, np.pi, 60)\n",
+    "X, Y = np.meshgrid(x, y)\n",
+    "Z = np.sin(X) * np.cos(Y)   # diverging data centred around 0\n",
+    "\n",
+    "fig6, ax6 = plt.subplots()\n",
+    "pc = ax6.pcolormesh(X, Y, Z, cmap='coolwarm', shading='auto')\n",
+    "fig6.colorbar(pc, ax=ax6, label='sin(x)·cos(y)')\n",
+    "ax6.set_title('sin(x)·cos(y)')\n",
+    "ax6.set_xlabel('x')\n",
+    "ax6.set_ylabel('y')\n",
+    "plt.close()\n",
+    "\n",
+    "# Switch to \"Diverging\" tab in the colormap picker to try RdBu_r, PiYG, seismic…\n",
+    "mplstudio.studio(fig6)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3a40a51c",
-   "source": "## 7. Mixed figure (categorical + continuous)\n\nWhen a figure contains both labeled series and a colormap-based artist, mplstudio shows **both** sets of controls.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 7. Mixed figure (categorical + continuous)\n",
+    "\n",
+    "When a figure contains both labeled series and a colormap-based artist, mplstudio shows **both** sets of controls."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "c7e809cc",
-   "source": "fig7, ax7 = plt.subplots()\n\n# Continuous background (contourf)\nx_c = np.linspace(-3, 3, 80)\ny_c = np.linspace(-3, 3, 80)\nXc, Yc = np.meshgrid(x_c, y_c)\nZc = np.exp(-(Xc**2 + Yc**2) / 4)\ncf = ax7.contourf(Xc, Yc, Zc, levels=12, cmap='Blues')\nfig7.colorbar(cf, ax=ax7, label='Gaussian')\n\n# Categorical overlay (scatter series)\nrng2 = np.random.default_rng(0)\nfor label, color in [('group A', '#E69F00'), ('group B', '#D55E00')]:\n    ax7.scatter(rng2.uniform(-2, 2, 30), rng2.uniform(-2, 2, 30),\n                label=label, edgecolors='white', linewidths=0.5, s=50)\nax7.legend()\nax7.set_title('Gaussian field + scatter overlay')\nplt.close()\n\n# Colors section shows \"Detected: mixed\" — both palette picker and colormap picker are visible\nmplstudio.studio(fig7)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "c7e809cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig7, ax7 = plt.subplots()\n",
+    "\n",
+    "# Continuous background (contourf)\n",
+    "x_c = np.linspace(-3, 3, 80)\n",
+    "y_c = np.linspace(-3, 3, 80)\n",
+    "Xc, Yc = np.meshgrid(x_c, y_c)\n",
+    "Zc = np.exp(-(Xc**2 + Yc**2) / 4)\n",
+    "cf = ax7.contourf(Xc, Yc, Zc, levels=12, cmap='Blues')\n",
+    "fig7.colorbar(cf, ax=ax7, label='Gaussian')\n",
+    "\n",
+    "# Categorical overlay (scatter series)\n",
+    "rng2 = np.random.default_rng(0)\n",
+    "for label, color in [('group A', '#E69F00'), ('group B', '#D55E00')]:\n",
+    "    ax7.scatter(rng2.uniform(-2, 2, 30), rng2.uniform(-2, 2, 30),\n",
+    "                label=label, edgecolors='white', linewidths=0.5, s=50)\n",
+    "ax7.legend()\n",
+    "ax7.set_title('Gaussian field + scatter overlay')\n",
+    "plt.close()\n",
+    "\n",
+    "# Colors section shows \"Detected: mixed\" — both palette picker and colormap picker are visible\n",
+    "mplstudio.studio(fig7)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "fc2d0de3",
    "metadata": {},
    "source": [
     "# mplstudio demo\n",
@@ -18,6 +19,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8673fd10",
    "metadata": {},
    "source": [
     "## 1. Line plot"
@@ -26,8 +28,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5c9cb54e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8485a37cc4864b84bea5e437c7facf2d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(HTML(value=\"<b style='font-size:1.1em'>mplstudio</b>\"), HBox(children=(HTML(valu…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -50,6 +68,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6c4aae4c",
    "metadata": {},
    "source": [
     "## 2. Scatter plot\n",
@@ -59,9 +78,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "f4b12979",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ed48cc39d21e4a22a6557e9c32104c0b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(HTML(value=\"<b style='font-size:1.1em'>mplstudio</b>\"), HBox(children=(HTML(valu…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "np.random.seed(0)\n",
     "\n",
@@ -78,6 +113,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bad1d08f",
    "metadata": {},
    "source": [
     "## 3. Programmatic API\n",
@@ -88,6 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7080f789",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,6 +147,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1aef804f",
    "metadata": {},
    "source": [
     "## 4. Color palette preview"
@@ -118,6 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c47d774c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,6 +178,48 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85ed5069",
+   "source": "## 5. Heatmap (continuous colormap)\n\nmplstudio auto-detects continuous data (`imshow`, `pcolormesh`) and shows a **colormap picker** with a gradient preview instead of the categorical palette controls.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "dc3f00ac",
+   "source": "import numpy as np\nimport matplotlib.pyplot as plt\nimport mplstudio\n\n# 2-D heatmap via imshow\nrng = np.random.default_rng(42)\ndata = rng.standard_normal((12, 12))\n\nfig5, ax5 = plt.subplots()\nim = ax5.imshow(data, cmap='viridis')\nfig5.colorbar(im, ax=ax5, label='value')\nax5.set_title('Random heatmap')\nplt.close()\n\n# Colors section shows \"Detected: continuous\" → colormap picker with gradient preview\nmplstudio.studio(fig5)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f19d7a37",
+   "source": "## 6. pcolormesh (continuous + diverging)\n\n`pcolormesh` is common for 2-D field data (e.g. atmospheric, oceanographic). mplstudio detects the scalar-mapped mesh and exposes the same colormap controls.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "48c0fe14",
+   "source": "x = np.linspace(-np.pi, np.pi, 60)\ny = np.linspace(-np.pi, np.pi, 60)\nX, Y = np.meshgrid(x, y)\nZ = np.sin(X) * np.cos(Y)   # diverging data centred around 0\n\nfig6, ax6 = plt.subplots()\npc = ax6.pcolormesh(X, Y, Z, cmap='coolwarm', shading='auto')\nfig6.colorbar(pc, ax=ax6, label='sin(x)·cos(y)')\nax6.set_title('sin(x)·cos(y)')\nax6.set_xlabel('x')\nax6.set_ylabel('y')\nplt.close()\n\n# Switch to \"Diverging\" tab in the colormap picker to try RdBu_r, PiYG, seismic…\nmplstudio.studio(fig6)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a40a51c",
+   "source": "## 7. Mixed figure (categorical + continuous)\n\nWhen a figure contains both labeled series and a colormap-based artist, mplstudio shows **both** sets of controls.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "c7e809cc",
+   "source": "fig7, ax7 = plt.subplots()\n\n# Continuous background (contourf)\nx_c = np.linspace(-3, 3, 80)\ny_c = np.linspace(-3, 3, 80)\nXc, Yc = np.meshgrid(x_c, y_c)\nZc = np.exp(-(Xc**2 + Yc**2) / 4)\ncf = ax7.contourf(Xc, Yc, Zc, levels=12, cmap='Blues')\nfig7.colorbar(cf, ax=ax7, label='Gaussian')\n\n# Categorical overlay (scatter series)\nrng2 = np.random.default_rng(0)\nfor label, color in [('group A', '#E69F00'), ('group B', '#D55E00')]:\n    ax7.scatter(rng2.uniform(-2, 2, 30), rng2.uniform(-2, 2, 30),\n                label=label, edgecolors='white', linewidths=0.5, s=50)\nax7.legend()\nax7.set_title('Gaussian field + scatter overlay')\nplt.close()\n\n# Colors section shows \"Detected: mixed\" — both palette picker and colormap picker are visible\nmplstudio.studio(fig7)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/mplstudio/__init__.py
+++ b/mplstudio/__init__.py
@@ -1,7 +1,11 @@
 """mplstudio — GUI styling tool for matplotlib figures in Jupyter."""
 
 from .widget import studio, available_sections
-from .palettes import PALETTES, get_palette, recommend, palette_names
+from .palettes import PALETTES, get_palette, recommend, palette_names, SEQUENTIAL_CMAPS, DIVERGING_CMAPS
 
 __version__ = "0.1.0"
-__all__ = ["studio", "available_sections", "PALETTES", "get_palette", "recommend", "palette_names"]
+__all__ = [
+    "studio", "available_sections",
+    "PALETTES", "get_palette", "recommend", "palette_names",
+    "SEQUENTIAL_CMAPS", "DIVERGING_CMAPS",
+]

--- a/mplstudio/__init__.py
+++ b/mplstudio/__init__.py
@@ -1,11 +1,16 @@
 """mplstudio — GUI styling tool for matplotlib figures in Jupyter."""
 
 from .widget import studio, available_sections
-from .palettes import PALETTES, get_palette, recommend, palette_names, SEQUENTIAL_CMAPS, DIVERGING_CMAPS
+from .palettes import (
+    PALETTES, get_palette, recommend, palette_names,
+    SEQUENTIAL_CMAPS, DIVERGING_CMAPS,
+    smart_palette, delta_e,
+)
 
 __version__ = "0.1.0"
 __all__ = [
     "studio", "available_sections",
     "PALETTES", "get_palette", "recommend", "palette_names",
     "SEQUENTIAL_CMAPS", "DIVERGING_CMAPS",
+    "smart_palette", "delta_e",
 ]

--- a/mplstudio/palettes.py
+++ b/mplstudio/palettes.py
@@ -1,92 +1,252 @@
-"""Curated color palettes and recommendation helpers."""
+"""Curated color palettes and smart recommendation helpers."""
 
 from __future__ import annotations
 
-# Each palette: {name, colors, tags, description}
+import math
+
+# ── palette registry ──────────────────────────────────────────────────────────
+# Tags: categorical | sequential | diverging | colorblind-safe | print-safe |
+#       light-background | dark-background | high-contrast | muted | vibrant |
+#       pastel | perceptually-uniform
+
 PALETTES: list[dict] = [
+    # ── Colorblind-safe / scientific ─────────────────────────────────────────
     {
         "name": "Okabe-Ito",
-        "colors": ["#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7", "#000000"],
+        "colors": ["#E69F00", "#56B4E9", "#009E73", "#F0E442",
+                   "#0072B2", "#D55E00", "#CC79A7", "#000000"],
+        "tags": ["colorblind-safe", "categorical", "print-safe"],
+        "description": "8-color colorblind-safe palette. Recommended by Nature Methods and IEEE.",
+        "source": "Okabe & Ito (2008), Nature Methods",
+    },
+    {
+        "name": "Paul Tol Bright",
+        "colors": ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"],
         "tags": ["colorblind-safe", "categorical"],
-        "description": "Colorblind-friendly palette by Okabe & Ito (2008).",
+        "description": "7-color bright qualitative palette from SRON. Safe for all common color-vision deficiencies.",
+        "source": "Paul Tol / SRON (personal.sron.nl/~pault)",
+    },
+    {
+        "name": "Paul Tol Vibrant",
+        "colors": ["#EE7733", "#0077BB", "#33BBEE", "#EE3377", "#CC3311", "#009988", "#BBBBBB"],
+        "tags": ["colorblind-safe", "categorical", "vibrant"],
+        "description": "7-color vibrant qualitative palette from SRON. High contrast, colorblind-safe.",
+        "source": "Paul Tol / SRON (personal.sron.nl/~pault)",
+    },
+    {
+        "name": "Paul Tol Muted",
+        "colors": ["#332288", "#88CCEE", "#44AA99", "#117733",
+                   "#999933", "#DDCC77", "#CC6677", "#882255", "#AA4499"],
+        "tags": ["colorblind-safe", "categorical", "muted"],
+        "description": "9-color muted qualitative palette from SRON. Good for dense figures.",
+        "source": "Paul Tol / SRON (personal.sron.nl/~pault)",
+    },
+    {
+        "name": "IBM Colorblind Safe",
+        "colors": ["#648FFF", "#785EF0", "#DC267F", "#FE6100", "#FFB000"],
+        "tags": ["colorblind-safe", "categorical", "high-contrast"],
+        "description": "5-color accessible palette from IBM Design Language / Carbon Design System.",
+        "source": "IBM Design Language (carbondesignsystem.com)",
+    },
+    # ── ColorBrewer qualitative ───────────────────────────────────────────────
+    {
+        "name": "ColorBrewer Set1",
+        "colors": ["#E41A1C", "#377EB8", "#4DAF4A", "#984EA3",
+                   "#FF7F00", "#FFFF33", "#A65628", "#F781BF", "#999999"],
+        "tags": ["categorical", "high-contrast"],
+        "description": "9-color high-contrast qualitative palette. Strong hue separation.",
+        "source": "ColorBrewer 2.0 (colorbrewer2.org)",
     },
     {
         "name": "ColorBrewer Set2",
-        "colors": ["#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3", "#A6D854", "#FFD92F", "#E5C494", "#B3B3B3"],
+        "colors": ["#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3",
+                   "#A6D854", "#FFD92F", "#E5C494", "#B3B3B3"],
         "tags": ["colorblind-safe", "categorical", "print-safe"],
-        "description": "Qualitative palette suitable for categorical data.",
+        "description": "8-color soft qualitative palette. Print-safe and colorblind-friendly.",
+        "source": "ColorBrewer 2.0 (colorbrewer2.org)",
     },
     {
-        "name": "Tableau 10",
-        "colors": ["#4E79A7", "#F28E2B", "#E15759", "#76B7B2", "#59A14F", "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC"],
-        "tags": ["categorical"],
-        "description": "Default Tableau palette, high contrast.",
+        "name": "ColorBrewer Dark2",
+        "colors": ["#1B9E77", "#D95F02", "#7570B3", "#E7298A",
+                   "#66A61E", "#E6AB02", "#A6761D", "#666666"],
+        "tags": ["colorblind-safe", "categorical", "print-safe", "muted"],
+        "description": "8-color darker qualitative palette. Earthy tones, print-safe.",
+        "source": "ColorBrewer 2.0 (colorbrewer2.org)",
     },
+    {
+        "name": "ColorBrewer Paired",
+        "colors": ["#A6CEE3", "#1F78B4", "#B2DF8A", "#33A02C",
+                   "#FB9A99", "#E31A1C", "#FDBF6F", "#FF7F00",
+                   "#CAB2D6", "#6A3D9A", "#FFFF99", "#B15928"],
+        "tags": ["categorical", "print-safe"],
+        "description": "12-color paired palette (light+dark pairs). Great for 6 paired series.",
+        "source": "ColorBrewer 2.0 (colorbrewer2.org)",
+    },
+    # ── Popular software defaults ─────────────────────────────────────────────
+    {
+        "name": "Tableau 10",
+        "colors": ["#4E79A7", "#F28E2B", "#E15759", "#76B7B2", "#59A14F",
+                   "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC"],
+        "tags": ["categorical"],
+        "description": "10-color Tableau default. Designed by Maureen Stone for high perceptual distinctiveness.",
+        "source": "Tableau (Maureen Stone)",
+    },
+    {
+        "name": "Matplotlib tab10",
+        "colors": ["#1F77B4", "#FF7F0E", "#2CA02C", "#D62728", "#9467BD",
+                   "#8C564B", "#E377C2", "#7F7F7F", "#BCBD22", "#17BECF"],
+        "tags": ["categorical"],
+        "description": "10-color matplotlib default (also D3 Category10 / Vega-Lite default).",
+        "source": "Matplotlib / D3.js",
+    },
+    # ── Sequential ────────────────────────────────────────────────────────────
     {
         "name": "Viridis (5 steps)",
         "colors": ["#440154", "#3B528B", "#21908C", "#5DC963", "#FDE725"],
         "tags": ["sequential", "colorblind-safe", "perceptually-uniform"],
         "description": "5-step sample of the perceptually uniform Viridis colormap.",
+        "source": "Matplotlib",
     },
+    # ── Diverging ─────────────────────────────────────────────────────────────
     {
         "name": "Coolwarm (diverging)",
         "colors": ["#3B4CC0", "#7B9FF9", "#DDDDDD", "#F4987A", "#B40426"],
         "tags": ["diverging"],
         "description": "5-step diverging palette for data centered around zero.",
+        "source": "Matplotlib",
     },
+    # ── Presentation / light background ──────────────────────────────────────
     {
         "name": "Pastel",
         "colors": ["#AEC6CF", "#FFD1DC", "#B5EAD7", "#FFDAC1", "#C7CEEA", "#FF9AA2"],
-        "tags": ["categorical", "light-background"],
-        "description": "Soft pastel tones, good for presentations.",
+        "tags": ["categorical", "light-background", "pastel"],
+        "description": "Soft pastel tones. Good for slides and posters.",
+        "source": "mplstudio curated",
     },
     {
         "name": "High Contrast",
-        "colors": ["#000000", "#FFFFFF", "#E69F00", "#56B4E9", "#009E73", "#D55E00"],
-        "tags": ["colorblind-safe", "high-contrast"],
-        "description": "Maximum contrast for accessibility.",
+        "colors": ["#000000", "#E69F00", "#56B4E9", "#009E73", "#D55E00", "#CC79A7"],
+        "tags": ["colorblind-safe", "high-contrast", "categorical"],
+        "description": "Maximum perceptual contrast. Subset of Okabe-Ito with black first.",
+        "source": "mplstudio curated",
     },
+    # ── Editor / dark-background themes ──────────────────────────────────────
     {
         "name": "Nord",
-        "colors": ["#BF616A", "#D08770", "#EBCB8B", "#A3BE8C", "#88C0D0", "#81A1C1", "#5E81AC", "#B48EAD"],
+        "colors": ["#BF616A", "#D08770", "#EBCB8B", "#A3BE8C",
+                   "#88C0D0", "#81A1C1", "#5E81AC", "#B48EAD"],
         "tags": ["categorical", "muted", "dark-background"],
-        "description": "Arctic, north-bluish accent colors from the Nord theme.",
+        "description": "Arctic-inspired muted accent colors from the Nord editor theme.",
+        "source": "Nord theme (nordtheme.com)",
     },
     {
         "name": "Catppuccin Latte",
-        "colors": ["#D20F39", "#FE640B", "#DF8E1D", "#40A02B", "#04A5E5", "#8839EF", "#EA76CB", "#E64553"],
+        "colors": ["#D20F39", "#FE640B", "#DF8E1D", "#40A02B",
+                   "#04A5E5", "#8839EF", "#EA76CB", "#E64553"],
         "tags": ["categorical", "pastel", "light-background"],
-        "description": "Warm pastel tones from the Catppuccin Latte theme.",
+        "description": "Warm pastel tones from the Catppuccin Latte light theme.",
+        "source": "Catppuccin (github.com/catppuccin)",
     },
     {
         "name": "Dracula",
-        "colors": ["#FF5555", "#FFB86C", "#F1FA8C", "#50FA7B", "#8BE9FD", "#BD93F9", "#FF79C6", "#6272A4"],
+        "colors": ["#FF5555", "#FFB86C", "#F1FA8C", "#50FA7B",
+                   "#8BE9FD", "#BD93F9", "#FF79C6", "#6272A4"],
         "tags": ["categorical", "dark-background", "vibrant"],
-        "description": "Vivid accent colors from the Dracula dark theme.",
+        "description": "Vivid accent colors from the Dracula dark editor theme.",
+        "source": "Dracula theme (draculatheme.com)",
     },
     {
         "name": "Tokyo Night",
-        "colors": ["#F7768E", "#FF9E64", "#E0AF68", "#9ECE6A", "#73DACA", "#7DCFFF", "#7AA2F7", "#BB9AF7"],
+        "colors": ["#F7768E", "#FF9E64", "#E0AF68", "#9ECE6A",
+                   "#73DACA", "#7DCFFF", "#7AA2F7", "#BB9AF7"],
         "tags": ["categorical", "dark-background", "vibrant"],
-        "description": "Neon-tinged accents from the Tokyo Night editor theme.",
+        "description": "Neon-tinged accent colors from the Tokyo Night editor theme.",
+        "source": "Tokyo Night theme",
     },
 ]
 
 
+# ── perceptual scoring ────────────────────────────────────────────────────────
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    h = hex_color.lstrip("#")
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def _distinctiveness(colors: list[str], n: int) -> float:
+    """Minimum pairwise Euclidean distance in RGB space for the first *n* colors.
+
+    Higher = more perceptually distinct. Used to rank palette recommendations.
+    """
+    subset = [_hex_to_rgb(c) for c in colors[:n]]
+    if len(subset) < 2:
+        return 0.0
+    min_dist = math.inf
+    for i in range(len(subset)):
+        for j in range(i + 1, len(subset)):
+            d = math.sqrt(sum((a - b) ** 2 for a, b in zip(subset[i], subset[j])))
+            if d < min_dist:
+                min_dist = d
+    return min_dist
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
 def get_palette(name: str) -> list[str]:
+    """Return the hex color list for *name*. Raises ``KeyError`` if not found."""
     for p in PALETTES:
         if p["name"] == name:
             return p["colors"]
     raise KeyError(f"Palette '{name}' not found.")
 
 
-def recommend(n_colors: int, *, colorblind_safe: bool = False) -> list[dict]:
-    """Return palettes with at least n_colors that match optional filters."""
+def recommend(
+    n_colors: int,
+    *,
+    colorblind_safe: bool = False,
+    use_case: str | None = None,
+    background: str | None = None,
+    top_k: int | None = None,
+) -> list[dict]:
+    """Return palettes ranked by perceptual distinctiveness.
+
+    Parameters
+    ----------
+    n_colors:
+        Only palettes with at least this many colors are returned.
+    colorblind_safe:
+        If ``True``, restrict to palettes tagged ``"colorblind-safe"``.
+    use_case:
+        ``"categorical"``, ``"sequential"``, or ``"diverging"``.
+        Filters to palettes that carry the matching tag.
+    background:
+        ``"light"`` or ``"dark"``. Excludes palettes designed for the
+        opposite background when alternatives exist.
+    top_k:
+        Return at most this many results. ``None`` returns all matches.
+    """
     results = [p for p in PALETTES if len(p["colors"]) >= n_colors]
+
     if colorblind_safe:
         results = [p for p in results if "colorblind-safe" in p["tags"]]
+    if use_case:
+        results = [p for p in results if use_case in p["tags"]]
+    if background == "light":
+        filtered = [p for p in results if "dark-background" not in p["tags"]]
+        if filtered:
+            results = filtered
+    elif background == "dark":
+        filtered = [p for p in results if "light-background" not in p["tags"]]
+        if filtered:
+            results = filtered
+
+    results.sort(key=lambda p: _distinctiveness(p["colors"], n_colors), reverse=True)
+
+    if top_k is not None:
+        results = results[:top_k]
     return results
 
 
 def palette_names() -> list[str]:
+    """Return all palette names in registry order."""
     return [p["name"] for p in PALETTES]

--- a/mplstudio/palettes.py
+++ b/mplstudio/palettes.py
@@ -166,28 +166,140 @@ PALETTES: list[dict] = [
 ]
 
 
-# ── perceptual scoring ────────────────────────────────────────────────────────
+# ── CIELAB color math (no external deps) ─────────────────────────────────────
 
-def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+def _rgb_to_lab(hex_color: str) -> tuple[float, float, float]:
+    """Hex → CIELAB (D65 illuminant, sRGB primaries)."""
     h = hex_color.lstrip("#")
-    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    r, g, b = (int(h[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
+
+    def _lin(c: float) -> float:  # sRGB → linear
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = _lin(r), _lin(g), _lin(b)
+
+    # Linear RGB → XYZ (D65), then normalise by D65 white point
+    x = (r * 0.4124564 + g * 0.3575761 + b * 0.1804375) / 0.95047
+    y = (r * 0.2126729 + g * 0.7151522 + b * 0.0721750) / 1.00000
+    z = (r * 0.0193339 + g * 0.1191920 + b * 0.9503041) / 1.08883
+
+    def _f(t: float) -> float:  # XYZ → LAB cube-root transfer
+        return t ** (1 / 3) if t > 0.008856 else 7.787 * t + 16 / 116
+
+    return 116 * _f(y) - 16, 500 * (_f(x) - _f(y)), 200 * (_f(y) - _f(z))
+
+
+def delta_e(c1: str, c2: str) -> float:
+    """ΔE 76 — Euclidean distance in CIELAB. Perceptually uniform proxy."""
+    L1, a1, b1 = _rgb_to_lab(c1)
+    L2, a2, b2 = _rgb_to_lab(c2)
+    return math.sqrt((L1 - L2) ** 2 + (a1 - a2) ** 2 + (b1 - b2) ** 2)
 
 
 def _distinctiveness(colors: list[str], n: int) -> float:
-    """Minimum pairwise Euclidean distance in RGB space for the first *n* colors.
-
-    Higher = more perceptually distinct. Used to rank palette recommendations.
-    """
-    subset = [_hex_to_rgb(c) for c in colors[:n]]
+    """Minimum pairwise ΔE 76 for the first *n* colors. Higher = more distinct."""
+    subset = colors[:n]
     if len(subset) < 2:
         return 0.0
-    min_dist = math.inf
+    min_d = math.inf
     for i in range(len(subset)):
         for j in range(i + 1, len(subset)):
-            d = math.sqrt(sum((a - b) ** 2 for a, b in zip(subset[i], subset[j])))
-            if d < min_dist:
-                min_dist = d
-    return min_dist
+            d = delta_e(subset[i], subset[j])
+            if d < min_d:
+                min_d = d
+    return min_d
+
+
+# ── smart 50-color pool (greedy farthest-point in CIELAB) ────────────────────
+
+# ~65 candidate colors sampled from authoritative palettes, covering the full
+# hue range with reasonable lightness (not too light, not too dark).
+_CANDIDATE_POOL: list[str] = [
+    # reds / vermillion
+    "#E41A1C", "#CC3311", "#EE3377", "#D55E00", "#EE6677",
+    "#DC267F", "#CC6677", "#882255", "#E15759",
+    # orange
+    "#E69F00", "#FF7F00", "#FE6100", "#F28E2B", "#EE7733", "#D95F02",
+    # yellow / gold
+    "#CCBB44", "#DDCC77", "#F0E442", "#FFB000", "#EDC948", "#E6AB02",
+    # green
+    "#009E73", "#228833", "#44AA99", "#009988", "#1B9E77",
+    "#117733", "#66A61E", "#4DAF4A", "#59A14F", "#A3BE8C",
+    # cyan / teal
+    "#56B4E9", "#66CCEE", "#33BBEE", "#0077BB", "#76B7B2", "#17BECF",
+    # blue
+    "#0072B2", "#4477AA", "#377EB8", "#332288", "#4E79A7",
+    "#1F78B4", "#648FFF", "#5E81AC",
+    # purple / violet
+    "#AA3377", "#AA4499", "#785EF0", "#7570B3", "#9467BD",
+    "#B48EAD", "#8839EF", "#984EA3",
+    # pink / magenta
+    "#CC79A7", "#F781BF", "#E7298A", "#FF79C6", "#EA76CB",
+    # neutral / earth
+    "#666666", "#7F7F7F", "#999933", "#A6761D", "#8C564B",
+]
+
+
+_SMART_POOL_CACHE: list[str] | None = None
+
+
+def _build_smart_pool() -> list[str]:
+    """Greedy farthest-point sampling in CIELAB. Runs once; O(m²) precompute."""
+    cands = _CANDIDATE_POOL
+    m = len(cands)
+    target = min(50, m)
+
+    # Precompute full pairwise ΔE matrix
+    dist: list[list[float]] = [[0.0] * m for _ in range(m)]
+    for i in range(m):
+        for j in range(i + 1, m):
+            d = delta_e(cands[i], cands[j])
+            dist[i][j] = dist[j][i] = d
+
+    # Seed: pair with the largest pairwise ΔE
+    bi, bj, bd = 0, 1, 0.0
+    for i in range(m):
+        for j in range(i + 1, m):
+            if dist[i][j] > bd:
+                bd, bi, bj = dist[i][j], i, j
+
+    selected: list[int] = [bi, bj]
+    in_sel: set[int] = {bi, bj}
+    # Track each candidate's min-distance to the selected set
+    min_d_to_sel = [min(dist[k][bi], dist[k][bj]) for k in range(m)]
+
+    while len(selected) < target:
+        # Pick the unselected candidate that maximises its min-distance to the set
+        best_k, best_val = -1, -1.0
+        for k in range(m):
+            if k in in_sel:
+                continue
+            if min_d_to_sel[k] > best_val:
+                best_val, best_k = min_d_to_sel[k], k
+        if best_k == -1:
+            break
+        selected.append(best_k)
+        in_sel.add(best_k)
+        # Update min-distances incrementally
+        for k in range(m):
+            if k not in in_sel and dist[k][best_k] < min_d_to_sel[k]:
+                min_d_to_sel[k] = dist[k][best_k]
+
+    return [cands[i] for i in selected]
+
+
+def smart_palette(n: int) -> list[str]:
+    """Return the top-*n* colors from the greedy-optimised 50-color pool.
+
+    Colors are ordered so that ``smart_palette(k)`` ⊆ ``smart_palette(k+1)``
+    for any k — the first *n* colors are always the most perceptually distinct
+    *n*-color combination available in the pool.
+    """
+    global _SMART_POOL_CACHE
+    if _SMART_POOL_CACHE is None:
+        _SMART_POOL_CACHE = _build_smart_pool()
+    pool = _SMART_POOL_CACHE
+    return pool[: max(1, min(n, len(pool)))]
 
 
 # ── public API ────────────────────────────────────────────────────────────────

--- a/mplstudio/palettes.py
+++ b/mplstudio/palettes.py
@@ -250,3 +250,17 @@ def recommend(
 def palette_names() -> list[str]:
     """Return all palette names in registry order."""
     return [p["name"] for p in PALETTES]
+
+
+# ── continuous colormap lists ─────────────────────────────────────────────────
+# Curated subsets of matplotlib colormaps, grouped by type.
+
+SEQUENTIAL_CMAPS: list[str] = [
+    "viridis", "plasma", "inferno", "magma", "cividis",  # perceptually uniform
+    "Blues", "Oranges", "Reds", "Greens", "Purples",     # single-hue
+    "YlOrRd", "YlGnBu", "BuPu", "GnBu",                 # multi-hue
+]
+
+DIVERGING_CMAPS: list[str] = [
+    "coolwarm", "RdBu_r", "PiYG", "PRGn", "RdYlGn", "seismic",
+]

--- a/mplstudio/style.py
+++ b/mplstudio/style.py
@@ -10,6 +10,44 @@ from matplotlib.lines import Line2D
 from .palettes import get_palette
 
 
+# ── continuous artist helpers ─────────────────────────────────────────────────
+
+def _continuous_artists(fig: Figure):
+    """Yield artists that carry a scalar colormap (AxesImage, QuadMesh, etc.)."""
+    for ax in fig.axes:
+        for img in ax.get_images():
+            yield img
+        for coll in ax.collections:
+            lbl = getattr(coll, "get_label", lambda: "_")()
+            # Unlabeled collections with scalar data → continuous (pcolormesh, contourf…)
+            if lbl.startswith("_") and hasattr(coll, "get_array") and coll.get_array() is not None:
+                yield coll
+
+
+def detect_plot_type(fig: Figure) -> str:
+    """Return ``'categorical'``, ``'continuous'``, or ``'mixed'`` based on figure contents."""
+    has_categorical = bool(get_line_labels(fig))
+    has_continuous = any(True for _ in _continuous_artists(fig))
+    if has_categorical and has_continuous:
+        return "mixed"
+    if has_continuous:
+        return "continuous"
+    return "categorical"
+
+
+def set_colormap(fig: Figure, cmap_name: str) -> None:
+    """Apply *cmap_name* to all image and scalar-mapped collection artists."""
+    for artist in _continuous_artists(fig):
+        artist.set_cmap(cmap_name)
+
+
+def get_colormap(fig: Figure) -> str | None:
+    """Return the colormap name of the first continuous artist, or ``None``."""
+    for artist in _continuous_artists(fig):
+        return artist.get_cmap().name
+    return None
+
+
 # ── artist helpers ────────────────────────────────────────────────────────────
 
 def _labeled_artists(ax):

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -11,7 +11,7 @@ from IPython.display import display
 from matplotlib.figure import Figure
 
 from . import style as S
-from .palettes import PALETTES, palette_names
+from .palettes import PALETTES, palette_names, SEQUENTIAL_CMAPS, DIVERGING_CMAPS
 
 _PREVIEW_HEIGHT = 400  # px — fixed height for the fitted preview mode
 
@@ -202,78 +202,140 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
 
     # ══ Colors ════════════════════════════════════════════════════════════
     if "colors" in active:
-        color_mode = widgets.ToggleButtons(
-            options=["Palette", "Manual"], value="Palette",
-            description="Mode:", style={"button_width": "72px"},
-            layout=widgets.Layout(width="100%", margin="0 0 4px 0"),
-        )
-        palette_select = widgets.Dropdown(
-            options=palette_names(), description="Palette",
-            style={"description_width": "58px"},
-            layout=widgets.Layout(width="100%"),
-        )
-        palette_preview = _build_palette_preview(palette_names()[0])
-        palette_row = widgets.HBox(
-            [palette_select, palette_preview],
-            layout=widgets.Layout(width="100%"),
+        plot_type = S.detect_plot_type(fig)
+        n_series = len(S.get_line_labels(fig))
+
+        # Type badge
+        _type_label = {
+            "categorical": f"categorical · {n_series} series",
+            "continuous": "continuous (colormap)",
+            "mixed": f"mixed · {n_series} categorical series + colormap",
+        }[plot_type]
+        type_badge = widgets.HTML(
+            f"<span style='font-size:0.78em;color:#888'>Detected: {_type_label}</span>"
         )
 
-        line_colors = S.get_line_colors(fig)
-        line_labels = S.get_line_labels(fig)
-        manual_pickers = [
-            widgets.ColorPicker(
-                value=color,
-                description=(label[:13] + "…" if len(label) > 13 else label),
-                style={"description_width": "82px"}, concise=False,
+        # ── Categorical controls ──────────────────────────────────────────
+        cat_box_children: list[widgets.Widget] = []
+
+        if plot_type in ("categorical", "mixed"):
+            color_mode = widgets.ToggleButtons(
+                options=["Palette", "Manual"], value="Palette",
+                description="Mode:", style={"button_width": "72px"},
+                layout=widgets.Layout(width="100%", margin="0 0 4px 0"),
+            )
+            palette_select = widgets.Dropdown(
+                options=palette_names(), description="Palette",
+                style={"description_width": "58px"},
                 layout=widgets.Layout(width="100%"),
             )
-            for color, label in zip(line_colors, line_labels)
-        ]
-        manual_section = widgets.VBox(
-            manual_pickers if manual_pickers
-            else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")]
-        )
-        manual_section.layout.display = "none"
+            palette_preview_w = _build_palette_preview(palette_names()[0])
+            palette_col = widgets.VBox(
+                [palette_select, palette_preview_w],
+                layout=widgets.Layout(width="100%"),
+            )
 
+            line_colors = S.get_line_colors(fig)
+            line_labels = S.get_line_labels(fig)
+            manual_pickers = [
+                widgets.ColorPicker(
+                    value=color,
+                    description=(label[:13] + "…" if len(label) > 13 else label),
+                    style={"description_width": "82px"}, concise=False,
+                    layout=widgets.Layout(width="100%"),
+                )
+                for color, label in zip(line_colors, line_labels)
+            ]
+            manual_section = widgets.VBox(
+                manual_pickers if manual_pickers
+                else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")]
+            )
+            manual_section.layout.display = "none"
+
+            def _apply_colors():
+                if color_mode.value == "Manual":
+                    S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
+                else:
+                    S.set_line_colors(fig, palette_select.value)
+                _refresh()
+
+            def _on_palette_change(change):
+                palette_preview_w.value = _build_palette_preview(change["new"]).value
+                _apply_colors()
+
+            def _on_color_mode_change(change):
+                if change["new"] == "Manual":
+                    palette_col.layout.display = "none"
+                    manual_section.layout.display = ""
+                else:
+                    palette_col.layout.display = ""
+                    manual_section.layout.display = "none"
+                _apply_colors()
+
+            palette_select.observe(_on_palette_change, names="value")
+            color_mode.observe(_on_color_mode_change, names="value")
+            for picker in manual_pickers:
+                picker.observe(lambda _: _apply_colors(), names="value")
+
+            cat_box_children = [color_mode, palette_col, manual_section]
+
+        # ── Continuous / colormap controls ────────────────────────────────
+        cmap_box_children: list[widgets.Widget] = []
+
+        if plot_type in ("continuous", "mixed"):
+            if plot_type == "mixed":
+                cmap_box_children.append(
+                    widgets.HTML("<hr style='margin:4px 0;border-color:#e0e0e0'>")
+                )
+            cmap_type_tb = widgets.ToggleButtons(
+                options=["Sequential", "Diverging"], value="Sequential",
+                style={"button_width": "90px"},
+                layout=widgets.Layout(width="100%"),
+            )
+            _init_cmap = S.get_colormap(fig) or "viridis"
+            _init_type = "Sequential" if _init_cmap in SEQUENTIAL_CMAPS else "Diverging"
+            cmap_type_tb.value = _init_type
+
+            cmap_select = widgets.Dropdown(
+                options=SEQUENTIAL_CMAPS if _init_type == "Sequential" else DIVERGING_CMAPS,
+                value=_init_cmap if _init_cmap in (SEQUENTIAL_CMAPS + DIVERGING_CMAPS) else SEQUENTIAL_CMAPS[0],
+                description="Colormap",
+                style={"description_width": "68px"},
+                layout=widgets.Layout(width="100%"),
+            )
+            cmap_grad_w = _build_colormap_gradient(cmap_select.value)
+
+            def _on_cmap_type(change):
+                opts = SEQUENTIAL_CMAPS if change["new"] == "Sequential" else DIVERGING_CMAPS
+                cmap_select.options = opts
+                cmap_select.value = opts[0]
+
+            def _on_cmap(change):
+                cmap_grad_w.value = _build_colormap_gradient(change["new"]).value
+                S.set_colormap(fig, change["new"])
+                _refresh()
+
+            cmap_type_tb.observe(_on_cmap_type, names="value")
+            cmap_select.observe(_on_cmap, names="value")
+            cmap_box_children += [cmap_type_tb, cmap_select, cmap_grad_w]
+
+        # ── Background ────────────────────────────────────────────────────
         bg_color = widgets.ColorPicker(
             value="#ffffff", description="Background",
             style={"description_width": "82px"}, concise=False,
             layout=widgets.Layout(width="100%"),
         )
 
-        def _apply_colors():
-            if color_mode.value == "Manual":
-                S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
-            else:
-                S.set_line_colors(fig, palette_select.value)
-            _refresh()
-
-        def _on_palette_change(change):
-            palette_row.children = (palette_select, _build_palette_preview(change["new"]))
-            _apply_colors()
-
-        def _on_color_mode_change(change):
-            if change["new"] == "Manual":
-                palette_row.layout.display = "none"
-                manual_section.layout.display = ""
-            else:
-                palette_row.layout.display = ""
-                manual_section.layout.display = "none"
-            _apply_colors()
-
         def _on_bg_change(change):
             if len(change["new"]) == 7:
                 S.set_background_color(fig, change["new"])
                 _refresh()
 
-        palette_select.observe(_on_palette_change, names="value")
-        color_mode.observe(_on_color_mode_change, names="value")
         bg_color.observe(_on_bg_change, names="value")
-        for picker in manual_pickers:
-            picker.observe(lambda _: _apply_colors(), names="value")
 
         sections.append(_section(
-            "Colors", color_mode, palette_row, manual_section, bg_color,
+            "Colors", type_badge,
+            *cat_box_children, *cmap_box_children, bg_color,
         ))
 
     # ══ Opacity (Alpha) ═══════════════════════════════════════════════════
@@ -625,9 +687,28 @@ def _build_palette_preview(name: str) -> widgets.HTML:
     colors = get_palette(name)
     swatches = "".join(
         f"<span style='background:{c};display:inline-block;width:16px;height:16px;"
-        f"margin:1px;border-radius:2px;border:1px solid #ccc'></span>"
+        f"margin:2px 2px 0 0;border-radius:3px;border:1px solid #ccc'></span>"
         for c in colors
     )
     return widgets.HTML(
-        value=f"<div style='margin-left:6px;line-height:18px'>{swatches}</div>"
+        value=f"<div style='display:flex;flex-wrap:wrap;margin-top:4px'>{swatches}</div>"
+    )
+
+
+def _build_colormap_gradient(cmap_name: str, steps: int = 24) -> widgets.HTML:
+    import matplotlib.cm as cm
+    import matplotlib.colors as mcolors
+    try:
+        cmap = cm.get_cmap(cmap_name)
+    except ValueError:
+        return widgets.HTML(value="")
+    stops = ", ".join(
+        mcolors.to_hex(cmap(i / (steps - 1))) for i in range(steps)
+    )
+    return widgets.HTML(
+        value=(
+            f"<div style='background:linear-gradient(to right,{stops});"
+            f"height:14px;border-radius:3px;margin-top:4px;"
+            f"border:1px solid #ccc'></div>"
+        )
     )

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -11,7 +11,9 @@ from IPython.display import display
 from matplotlib.figure import Figure
 
 from . import style as S
-from .palettes import PALETTES, palette_names, SEQUENTIAL_CMAPS, DIVERGING_CMAPS
+from .palettes import (
+    PALETTES, palette_names, SEQUENTIAL_CMAPS, DIVERGING_CMAPS, smart_palette,
+)
 
 _PREVIEW_HEIGHT = 400  # px — fixed height for the fitted preview mode
 
@@ -220,10 +222,11 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
 
         if plot_type in ("categorical", "mixed"):
             color_mode = widgets.ToggleButtons(
-                options=["Palette", "Manual"], value="Palette",
-                description="Mode:", style={"button_width": "72px"},
+                options=["Palette", "Manual", "Smart"], value="Palette",
+                description="Mode:", style={"button_width": "62px"},
                 layout=widgets.Layout(width="100%", margin="0 0 4px 0"),
             )
+            # ── Palette sub-section ───────────────────────────────────────
             palette_select = widgets.Dropdown(
                 options=palette_names(), description="Palette",
                 style={"description_width": "58px"},
@@ -234,7 +237,7 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
                 [palette_select, palette_preview_w],
                 layout=widgets.Layout(width="100%"),
             )
-
+            # ── Manual sub-section ────────────────────────────────────────
             line_colors = S.get_line_colors(fig)
             line_labels = S.get_line_labels(fig)
             manual_pickers = [
@@ -251,10 +254,30 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
                 else [widgets.HTML("<i style='color:#888'>No labeled series found.</i>")]
             )
             manual_section.layout.display = "none"
+            # ── Smart sub-section ─────────────────────────────────────────
+            _smart_init_n = max(2, min(n_series or 5, 10))
+            smart_n = widgets.IntSlider(
+                value=_smart_init_n, min=2, max=20, step=1,
+                description="Colors (n)",
+                style={"description_width": "78px"},
+                layout=widgets.Layout(width="100%"),
+                continuous_update=False,
+            )
+            smart_preview_w = widgets.HTML(
+                value=_swatches_div(smart_palette(_smart_init_n))
+            )
+            smart_section = widgets.VBox(
+                [smart_n, smart_preview_w],
+                layout=widgets.Layout(width="100%"),
+            )
+            smart_section.layout.display = "none"
 
             def _apply_colors():
-                if color_mode.value == "Manual":
+                mode = color_mode.value
+                if mode == "Manual":
                     S.set_line_colors_manual(fig, [p.value for p in manual_pickers])
+                elif mode == "Smart":
+                    S.set_line_colors_manual(fig, smart_palette(smart_n.value))
                 else:
                     S.set_line_colors(fig, palette_select.value)
                 _refresh()
@@ -263,21 +286,29 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
                 palette_preview_w.value = _build_palette_preview(change["new"]).value
                 _apply_colors()
 
+            def _on_smart_n(change):
+                smart_preview_w.value = _swatches_div(smart_palette(change["new"]))
+                _apply_colors()
+
             def _on_color_mode_change(change):
+                palette_col.layout.display = "none"
+                manual_section.layout.display = "none"
+                smart_section.layout.display = "none"
                 if change["new"] == "Manual":
-                    palette_col.layout.display = "none"
                     manual_section.layout.display = ""
+                elif change["new"] == "Smart":
+                    smart_section.layout.display = ""
                 else:
                     palette_col.layout.display = ""
-                    manual_section.layout.display = "none"
                 _apply_colors()
 
             palette_select.observe(_on_palette_change, names="value")
             color_mode.observe(_on_color_mode_change, names="value")
+            smart_n.observe(_on_smart_n, names="value")
             for picker in manual_pickers:
                 picker.observe(lambda _: _apply_colors(), names="value")
 
-            cat_box_children = [color_mode, palette_col, manual_section]
+            cat_box_children = [color_mode, palette_col, manual_section, smart_section]
 
         # ── Continuous / colormap controls ────────────────────────────────
         cmap_box_children: list[widgets.Widget] = []
@@ -682,17 +713,19 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
     ))
 
 
-def _build_palette_preview(name: str) -> widgets.HTML:
-    from .palettes import get_palette
-    colors = get_palette(name)
-    swatches = "".join(
+def _swatches_div(colors: list[str]) -> str:
+    """Return an HTML string of flex-wrapped color swatches."""
+    spans = "".join(
         f"<span style='background:{c};display:inline-block;width:16px;height:16px;"
         f"margin:2px 2px 0 0;border-radius:3px;border:1px solid #ccc'></span>"
         for c in colors
     )
-    return widgets.HTML(
-        value=f"<div style='display:flex;flex-wrap:wrap;margin-top:4px'>{swatches}</div>"
-    )
+    return f"<div style='display:flex;flex-wrap:wrap;margin-top:4px'>{spans}</div>"
+
+
+def _build_palette_preview(name: str) -> widgets.HTML:
+    from .palettes import get_palette
+    return widgets.HTML(value=_swatches_div(get_palette(name)))
 
 
 def _build_colormap_gradient(cmap_name: str, steps: int = 24) -> widgets.HTML:

--- a/mplstudio/widget.py
+++ b/mplstudio/widget.py
@@ -516,8 +516,25 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
 
     # ══ Palette Suggestions ═══════════════════════════════════════════════
     if "palette_suggestions" in active:
+        suggest_use_case = widgets.Dropdown(
+            options=[("Any", None), ("Categorical", "categorical"),
+                     ("Sequential", "sequential"), ("Diverging", "diverging")],
+            value=None, description="Use case",
+            style={"description_width": "68px"},
+            layout=widgets.Layout(width="100%"),
+        )
+        suggest_bg = widgets.Dropdown(
+            options=[("Any", None), ("Light bg", "light"), ("Dark bg", "dark")],
+            value=None, description="Background",
+            style={"description_width": "68px"},
+            layout=widgets.Layout(width="100%"),
+        )
+        suggest_cb = widgets.Checkbox(
+            value=True, description="Colorblind-safe only",
+            layout=widgets.Layout(width="100%"),
+        )
         cb_recommend = widgets.Button(
-            description="Suggest colorblind-safe palette",
+            description="Find palettes",
             button_style="info", layout=widgets.Layout(width="100%"),
         )
         recommend_out = widgets.Output()
@@ -525,21 +542,37 @@ def studio(fig: Figure | None = None, *, show: list[str] | None = None) -> None:
         def _on_recommend(_):
             from .palettes import recommend
             n = len(S.get_line_labels(fig)) or 3
-            suggestions = recommend(n, colorblind_safe=True)
+            suggestions = recommend(
+                n,
+                colorblind_safe=suggest_cb.value,
+                use_case=suggest_use_case.value,
+                background=suggest_bg.value,
+                top_k=4,
+            )
             with recommend_out:
                 recommend_out.clear_output()
-                for p in suggestions[:3]:
+                if not suggestions:
+                    display(widgets.HTML(
+                        "<i style='color:#888'>No palettes match the current filters.</i>"
+                    ))
+                    return
+                for p in suggestions:
                     swatch = "".join(
                         f"<span style='background:{c};display:inline-block;"
-                        f"width:16px;height:16px;margin:1px;border-radius:2px'></span>"
+                        f"width:14px;height:14px;margin:1px;border-radius:2px'></span>"
                         for c in p["colors"][:n]
                     )
                     display(widgets.HTML(
-                        f"<b>{p['name']}</b> — {p['description']}<br>{swatch}<br>"
+                        f"<b>{p['name']}</b> {swatch}<br>"
+                        f"<span style='font-size:0.82em;color:#555'>{p['description']}</span><br>"
+                        f"<span style='font-size:0.78em;color:#888'>{p['source']}</span><br>"
                     ))
 
         cb_recommend.on_click(_on_recommend)
-        sections.append(_section("Palette Suggestions", cb_recommend, recommend_out))
+        sections.append(_section(
+            "Palette Suggestions",
+            suggest_use_case, suggest_bg, suggest_cb, cb_recommend, recommend_out,
+        ))
 
     # ══ Unknown section warning ════════════════════════════════════════════
     if unknown:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -343,3 +343,60 @@ def test_diverging_cmaps_list():
     from mplstudio.palettes import DIVERGING_CMAPS
     assert "coolwarm" in DIVERGING_CMAPS
     assert len(DIVERGING_CMAPS) >= 3
+
+
+# ── CIELAB / smart palette tests ──────────────────────────────────────────────
+
+def test_delta_e_identical():
+    from mplstudio.palettes import delta_e
+    assert delta_e("#FF0000", "#FF0000") == 0.0
+
+
+def test_delta_e_black_white():
+    from mplstudio.palettes import delta_e
+    # ΔE between black and white should be very large (≈100)
+    assert delta_e("#000000", "#ffffff") > 90
+
+
+def test_delta_e_red_blue_larger_than_red_orange():
+    from mplstudio.palettes import delta_e
+    de_rb = delta_e("#FF0000", "#0000FF")
+    de_ro = delta_e("#FF0000", "#FF8800")
+    assert de_rb > de_ro
+
+
+def test_smart_palette_length():
+    from mplstudio.palettes import smart_palette
+    for n in (2, 5, 10, 20):
+        assert len(smart_palette(n)) == n
+
+
+def test_smart_palette_subset_property():
+    from mplstudio.palettes import smart_palette
+    # smart_palette(n) must be a prefix of smart_palette(n+1)
+    for n in range(2, 12):
+        assert smart_palette(n) == smart_palette(n + 1)[:n]
+
+
+def test_smart_palette_returns_hex():
+    from mplstudio.palettes import smart_palette
+    for c in smart_palette(8):
+        assert c.startswith("#") and len(c) == 7
+
+
+def test_smart_palette_min_delta_e():
+    from mplstudio.palettes import smart_palette, delta_e
+    colors = smart_palette(8)
+    min_de = min(
+        delta_e(colors[i], colors[j])
+        for i in range(len(colors))
+        for j in range(i + 1, len(colors))
+    )
+    # All 8 colors should be at least ΔE 20 apart (perceptually very distinct)
+    assert min_de >= 20, f"min ΔE too low: {min_de:.1f}"
+
+
+def test_distinctiveness_uses_lab():
+    from mplstudio.palettes import _distinctiveness, delta_e
+    colors = ["#FF0000", "#0000FF"]
+    assert _distinctiveness(colors, 2) == pytest.approx(delta_e(colors[0], colors[1]))

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -265,3 +265,81 @@ def test_set_legend_bbox(fig):
     S.set_legend_bbox(fig, 0.8, 0.9)
     legend = fig.axes[0].get_legend()
     assert legend is not None  # smoke test — bbox_to_anchor set without error
+
+
+# ── continuous colormap tests ─────────────────────────────────────────────────
+
+@pytest.fixture
+def heatmap_fig():
+    import numpy as np
+    f, ax = plt.subplots()
+    data = np.arange(16).reshape(4, 4)
+    ax.imshow(data, cmap="viridis")
+    yield f
+    plt.close(f)
+
+
+@pytest.fixture
+def pcolormesh_fig():
+    import numpy as np
+    f, ax = plt.subplots()
+    x = np.linspace(0, 1, 5)
+    y = np.linspace(0, 1, 5)
+    X, Y = np.meshgrid(x, y)
+    ax.pcolormesh(X, Y, X * Y, cmap="coolwarm")
+    yield f
+    plt.close(f)
+
+
+def test_detect_categorical(fig):
+    assert S.detect_plot_type(fig) == "categorical"
+
+
+def test_detect_continuous_imshow(heatmap_fig):
+    assert S.detect_plot_type(heatmap_fig) == "continuous"
+
+
+def test_detect_continuous_pcolormesh(pcolormesh_fig):
+    assert S.detect_plot_type(pcolormesh_fig) == "continuous"
+
+
+def test_detect_mixed():
+    import numpy as np
+    f, ax = plt.subplots()
+    ax.plot([1, 2, 3], label="series")
+    ax.legend()
+    ax.imshow(np.zeros((3, 3)), cmap="viridis", aspect="auto", extent=[0, 3, 0, 3])
+    assert S.detect_plot_type(f) == "mixed"
+    plt.close(f)
+
+
+def test_get_colormap_imshow(heatmap_fig):
+    cmap = S.get_colormap(heatmap_fig)
+    assert cmap == "viridis"
+
+
+def test_set_colormap_imshow(heatmap_fig):
+    S.set_colormap(heatmap_fig, "plasma")
+    assert S.get_colormap(heatmap_fig) == "plasma"
+
+
+def test_set_colormap_pcolormesh(pcolormesh_fig):
+    S.set_colormap(pcolormesh_fig, "inferno")
+    assert S.get_colormap(pcolormesh_fig) == "inferno"
+
+
+def test_get_colormap_returns_none_for_categorical(fig):
+    assert S.get_colormap(fig) is None
+
+
+def test_sequential_cmaps_list():
+    from mplstudio.palettes import SEQUENTIAL_CMAPS
+    assert "viridis" in SEQUENTIAL_CMAPS
+    assert "plasma" in SEQUENTIAL_CMAPS
+    assert len(SEQUENTIAL_CMAPS) >= 5
+
+
+def test_diverging_cmaps_list():
+    from mplstudio.palettes import DIVERGING_CMAPS
+    assert "coolwarm" in DIVERGING_CMAPS
+    assert len(DIVERGING_CMAPS) >= 3

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -5,7 +5,7 @@ import pytest
 
 import mplstudio
 from mplstudio import style as S
-from mplstudio.palettes import get_palette, recommend
+from mplstudio.palettes import get_palette, recommend, palette_names
 
 
 @pytest.fixture
@@ -60,6 +60,48 @@ def test_recommend_colorblind():
     results = recommend(3, colorblind_safe=True)
     assert all("colorblind-safe" in p["tags"] for p in results)
     assert all(len(p["colors"]) >= 3 for p in results)
+
+
+def test_recommend_use_case():
+    results = recommend(3, use_case="categorical")
+    assert all("categorical" in p["tags"] for p in results)
+
+
+def test_recommend_background_light():
+    results = recommend(3, background="light")
+    assert all("dark-background" not in p["tags"] for p in results)
+
+
+def test_recommend_top_k():
+    results = recommend(3, top_k=2)
+    assert len(results) <= 2
+
+
+def test_recommend_ranked_by_distinctiveness():
+    from mplstudio.palettes import _distinctiveness
+    results = recommend(5)
+    scores = [_distinctiveness(p["colors"], 5) for p in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_recommend_no_match_returns_empty():
+    results = recommend(3, colorblind_safe=True, use_case="diverging")
+    # diverging + colorblind-safe may or may not match; just ensure it's a list
+    assert isinstance(results, list)
+
+
+def test_palette_has_source():
+    from mplstudio.palettes import PALETTES
+    for p in PALETTES:
+        assert "source" in p, f"Palette '{p['name']}' missing 'source' field"
+
+
+def test_new_palettes_present():
+    names = palette_names()
+    for expected in ["Paul Tol Bright", "Paul Tol Vibrant", "Paul Tol Muted",
+                     "IBM Colorblind Safe", "ColorBrewer Set1",
+                     "ColorBrewer Dark2", "ColorBrewer Paired", "Matplotlib tab10"]:
+        assert expected in names, f"Palette '{expected}' not found"
 
 
 def test_legend_color_synced_after_palette_change(fig):


### PR DESCRIPTION
Closes #6.

## Summary

- **Smart palette — 50-color greedy pool (closes #6)**
  - `_rgb_to_lab()` converts sRGB → CIELAB (D65, no external deps)
  - `delta_e(c1, c2)` — ΔE 76, Euclidean distance in CIELAB (public API)
  - `_distinctiveness()` upgraded from RGB Euclidean → ΔE 76; improves `recommend()` ranking quality
  - `_CANDIDATE_POOL` — 65 perceptually diverse candidate colors spanning the full hue range
  - `_build_smart_pool()` — greedy farthest-point sampling in CIELAB; O(m²) precompute, runs once and is cached; ordering guarantees `smart_palette(k) ⊆ smart_palette(k+1)`
  - `smart_palette(n)` — returns top-n from the ordered pool
  - **"Smart" mode** in the Colors section: IntSlider (2–20) + live swatch preview; applying calls `set_line_colors_manual(smart_palette(n))`

- **Palette library: 11 → 19 palettes** — Paul Tol Bright/Vibrant/Muted, IBM Colorblind Safe, ColorBrewer Set1/Dark2/Paired, Matplotlib tab10; each palette carries a `source` field; `recommend()` gains `use_case`, `background`, `top_k` params

- **Continuous colormap support** — `detect_plot_type()` auto-detects categorical / continuous / mixed; Colors section adapts accordingly with Sequential/Diverging toggle + dropdown + CSS gradient bar preview

- **Swatch layout fix** — flex-wrap swatches wrap cleanly at any column width

- **demo.ipynb** — cells 5–7: imshow heatmap, pcolormesh diverging, mixed contourf + scatter

## What's not in scope (intentionally deferred)

- CIELAB ΔE 2000 (CIE 2000 formula with weighting terms) — ΔE 76 is a good enough proxy for this use case
- Slider for n in the Palette Suggestions section (covered by the Smart mode in Colors)

## Test plan

- [ ] Colors section → "Smart" mode → drag n slider → swatches update and figure redraws
- [ ] `smart_palette(5)` ⊆ `smart_palette(6)` (subset property)
- [ ] All 8 colors in `smart_palette(8)` are ≥ ΔE 20 apart
- [ ] `recommend(3, use_case="categorical", background="light", top_k=3)` — sorted by ΔE 76 distinctiveness, no dark-background palettes
- [ ] Narrow Colors column — palette swatches wrap to next row
- [ ] `studio()` on imshow → "Detected: continuous", colormap picker shown
- [ ] `pytest tests/` → 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)