### PR TITLE
feat: scanpy UMAP support + palette= kwarg (closes #11)

### DIFF
--- a/examples/scanpy_umap.ipynb
+++ b/examples/scanpy_umap.ipynb
@@ -168,93 +168,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0e1f2a3",
-   "metadata": {},
-   "source": [
-    "## 3. Mixed figure — categorical overlay on continuous background\n",
-    "\n",
-    "Sometimes you want to overlay labelled scatter groups on top of a density contour or heatmap.  \n",
-    "mplstudio detects **both** and shows the full palette + colormap controls together."
-   ]
+   "id": "c494892e",
+   "source": "## 3. Heatmap (`sc.pl.heatmap`)\n\n`sc.pl.heatmap` renders a gene × group matrix as `imshow` — a continuous artist.  \nmplstudio detects it automatically and shows the **colormap picker** with a gradient preview.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e1f2a3b4",
+   "id": "308cf287",
+   "source": "MARKER_GENES = {\n    \"T cell\":   [\"CD3D\", \"CD3E\", \"CD8A\"],\n    \"B cell\":   [\"CD79A\", \"MS4A1\", \"CD19\"],\n    \"NK cell\":  [\"GNLY\", \"NKG7\", \"KLRD1\"],\n    \"Monocyte\": [\"LYZ\", \"CST3\", \"CD14\"],\n    \"DC\":       [\"FCER1A\", \"CST7\", \"CLEC9A\"],\n}\nCELL_TYPES = list(MARKER_GENES)\nGENES      = [g for gs in MARKER_GENES.values() for g in gs]\n\nif HAS_SCANPY:\n    # sc.pl.heatmap returns a dict of axes; the main heatmap axes contains an AxesImage\n    axes_dict = sc.pl.heatmap(\n        adata,\n        var_names=adata.var_names[:12],\n        groupby=\"bulk_labels\",\n        show=False,\n    )\n    fig_hm = axes_dict[\"heatmap_ax\"].get_figure()\n    plt.close()\n\nelse:\n    # Synthetic: mean log-normalised expression per cell type per gene\n    rng5 = np.random.default_rng(5)\n    # Base expression matrix: rows = cell types, cols = genes\n    base = np.zeros((len(CELL_TYPES), len(GENES)))\n    for i, ct in enumerate(CELL_TYPES):\n        for j, gene in enumerate(GENES):\n            # high if gene is a marker for this cell type\n            base[i, j] = 2.5 if gene in MARKER_GENES[ct] else 0.2\n    expr_matrix = (base + rng5.exponential(0.3, base.shape)).T  # genes × cell_types\n\n    fig_hm, ax_hm = plt.subplots(figsize=(6, 5))\n    im = ax_hm.imshow(expr_matrix, aspect=\"auto\", cmap=\"Reds\", vmin=0)\n    fig_hm.colorbar(im, ax=ax_hm, label=\"Mean expression (log-norm)\")\n    ax_hm.set_xticks(range(len(CELL_TYPES)))\n    ax_hm.set_xticklabels(CELL_TYPES, rotation=35, ha=\"right\", fontsize=9)\n    ax_hm.set_yticks(range(len(GENES)))\n    ax_hm.set_yticklabels(GENES, fontsize=8)\n    ax_hm.set_title(\"Marker gene expression per cell type\")\n    plt.tight_layout()\n    plt.close()\n\nmplstudio.studio(fig_hm)",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "rng3 = np.random.default_rng(2)\n",
-    "\n",
-    "# Continuous background: 2-D KDE-like density (contourf)\n",
-    "xg = np.linspace(-4, 4, 80)\n",
-    "yg = np.linspace(-4, 4, 80)\n",
-    "Xg, Yg = np.meshgrid(xg, yg)\n",
-    "density = (\n",
-    "    np.exp(-((Xg - 1.5)**2 + (Yg - 1.0)**2) / 2.5) +\n",
-    "    np.exp(-((Xg + 1.5)**2 + (Yg - 0.5)**2) / 2.0) * 0.7\n",
-    ")\n",
-    "\n",
-    "fig_mix, ax_mix = plt.subplots(figsize=(5, 4))\n",
-    "cf = ax_mix.contourf(Xg, Yg, density, levels=10, cmap=\"Blues\", alpha=0.6)\n",
-    "fig_mix.colorbar(cf, ax=ax_mix, label=\"cell density\")\n",
-    "\n",
-    "# Categorical overlay: two annotated populations\n",
-    "for name, cx, cy, col in [(\"Pop A\", 1.5, 1.0, \"#E69F00\"),\n",
-    "                           (\"Pop B\", -1.5, 0.5, \"#56B4E9\")]:\n",
-    "    xy = rng3.standard_normal((50, 2)) * 0.5 + [cx, cy]\n",
-    "    ax_mix.scatter(xy[:, 0], xy[:, 1], label=name, color=col,\n",
-    "                   edgecolors=\"white\", linewidths=0.4, s=30)\n",
-    "ax_mix.legend()\n",
-    "ax_mix.set_title(\"Density + categorical overlay\")\n",
-    "ax_mix.set_xlabel(\"UMAP1\")\n",
-    "ax_mix.set_ylabel(\"UMAP2\")\n",
-    "plt.close()\n",
-    "\n",
-    "mplstudio.studio(fig_mix)"
-   ]
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
-   "id": "f2a3b4c5",
-   "metadata": {},
-   "source": [
-    "## 4. Programmatic style API (no GUI)\n",
-    "\n",
-    "All style functions are accessible directly from `mplstudio.style` — useful for scripted figure generation."
-   ]
+   "id": "8ffa1c70",
+   "source": "**What to try:**\n\n- **Colors → Sequential**: `Reds` → `YlOrRd`, `viridis`, `plasma` 등으로 바꿔보기.\n- **Colors → Diverging**: `RdBu_r`나 `coolwarm`으로 up/down-regulated 유전자 강조.\n- **Typography**: 폰트 크기를 키우면 유전자 이름과 cell type 레이블 가독성이 올라감.\n- **Figure size**: 유전자 수에 맞게 세로 길이 조정.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "200e515f",
+   "source": "## 4. Violin plot (`sc.pl.violin`)\n\n`sc.pl.violin`은 cell type별 유전자 발현 분포를 보여주는 그래프.  \nViolin 패치(`PolyCollection`)는 레이블이 없기 때문에 **Colors 섹션은 \"No labeled series\"** 로 표시되며 색 변경은 지원되지 않는다.  \n대신 **Typography, Figure size, Grid, Spines** 컨트롤이 논문용 다듬기에 유용하다.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a3b4c5d6",
+   "id": "f0e24d38",
+   "source": "VIOLIN_GENES = [\"CD3D\", \"CD79A\", \"LYZ\"]  # T cell, B cell, Monocyte markers\n\nif HAS_SCANPY:\n    fig_vn, axes_vn = plt.subplots(1, len(VIOLIN_GENES), figsize=(9, 3), sharey=False)\n    for ax_v, gene in zip(axes_vn, VIOLIN_GENES):\n        sc.pl.violin(adata, keys=gene, groupby=\"bulk_labels\",\n                     ax=ax_v, show=False, rotation=35)\n    fig_vn.suptitle(\"Marker gene expression by cell type\")\n    plt.tight_layout()\n    plt.close()\n\nelse:\n    rng6 = np.random.default_rng(6)\n\n    # Simulate per-cell expression for 3 marker genes across 5 cell types\n    # Each gene is highly expressed in its cognate cell type\n    COGNATE = {\"CD3D\": \"T cell\", \"CD79A\": \"B cell\", \"LYZ\": \"Monocyte\"}\n    N_CELLS = 120  # per cell type\n\n    fig_vn, axes_vn = plt.subplots(1, len(VIOLIN_GENES), figsize=(9, 3), sharey=False)\n    for ax_v, gene in zip(axes_vn, VIOLIN_GENES):\n        all_data, all_pos, tick_labels = [], [], []\n        for k, ct in enumerate(CELL_TYPES):\n            high = (ct == COGNATE[gene])\n            mu  = rng6.uniform(1.8, 2.5) if high else rng6.uniform(0.0, 0.4)\n            sig = 0.4 if high else 0.3\n            vals = np.clip(rng6.normal(mu, sig, N_CELLS), 0, None)\n            all_data.append(vals)\n            tick_labels.append(ct)\n\n        # violinplot + strip-chart (same structure as scanpy)\n        parts = ax_v.violinplot(all_data, positions=range(len(CELL_TYPES)),\n                                showmedians=True, showextrema=False, widths=0.7)\n        for k, vals in enumerate(all_data):\n            jitter = rng6.uniform(-0.12, 0.12, len(vals))\n            ax_v.scatter(k + jitter, vals, s=2, alpha=0.3,\n                         color=\"#555555\", zorder=3)\n        # apply palette colours to violin bodies\n        for body, ct in zip(parts[\"bodies\"], CELL_TYPES):\n            body.set_facecolor(CELL_TYPE_COLORS[ct])\n            body.set_alpha(0.75)\n\n        ax_v.set_title(gene, fontsize=10)\n        ax_v.set_xticks(range(len(CELL_TYPES)))\n        ax_v.set_xticklabels(tick_labels, rotation=35, ha=\"right\", fontsize=8)\n        ax_v.set_ylabel(\"Expression\" if ax_v is axes_vn[0] else \"\")\n\n    fig_vn.suptitle(\"Marker gene expression by cell type\")\n    plt.tight_layout()\n    plt.close()\n\nmplstudio.studio(fig_vn)",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "from mplstudio import style as S\n",
-    "\n",
-    "# Rebuild the categorical figure and apply scanpy palette programmatically\n",
-    "rng4 = np.random.default_rng(0)\n",
-    "centres = {\"T cell\": (2, 1), \"B cell\": (-2, 1), \"NK cell\": (0, -2),\n",
-    "           \"Monocyte\": (2, -1), \"DC\": (-2, -1)}\n",
-    "\n",
-    "fig_api, ax_api = plt.subplots(figsize=(5, 4))\n",
-    "for ct, (cx, cy) in centres.items():\n",
-    "    xy = rng4.standard_normal((80, 2)) * 0.6 + [cx, cy]\n",
-    "    ax_api.scatter(xy[:, 0], xy[:, 1], label=ct, s=8, alpha=0.85)\n",
-    "ax_api.set_title(\"Before styling\")\n",
-    "\n",
-    "# Apply scanpy palette via the style API\n",
-    "labels  = S.get_line_labels(fig_api)\n",
-    "colors  = [CELL_TYPE_COLORS.get(lbl, \"#888888\") for lbl in labels]\n",
-    "S.set_line_colors_manual(fig_api, colors)\n",
-    "S.set_font_size(fig_api, 12)\n",
-    "S.set_spine_style(fig_api, \"2-Side\")\n",
-    "\n",
-    "ax_api.set_title(\"After styling\")\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af30f39d",
+   "source": "**What to try:**\n\n- **Typography**: 폰트 크기를 높이면 유전자 이름(subplot title)과 cell type x-tick 레이블 가독성이 올라감.\n- **Grid → On**: 수평 grid line을 켜면 발현 수치를 읽기 쉬워짐.\n- **Spines → 2-Side** 또는 **None**: 논문 스타일에 맞게 spine을 정리.\n- **Figure size**: 유전자를 더 추가할 때 가로 길이를 늘려 서브플롯 간격 확보.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/scanpy_umap.ipynb
+++ b/examples/scanpy_umap.ipynb
@@ -4,23 +4,7 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4",
    "metadata": {},
-   "source": [
-    "# mplstudio × scanpy\n",
-    "\n",
-    "mplstudio detects the two most common scanpy plot styles and adds a **`palette=`** kwarg to carry scanpy's colour assignments directly into the GUI.\n",
-    "\n",
-    "| Pattern | What scanpy does | What mplstudio does |\n",
-    "|---|---|---|\n",
-    "| Categorical UMAP | One `PathCollection` per category, no `ax.legend()` | Detects unlabeled collections, falls back to direct scan |\n",
-    "| Continuous UMAP | Single `PathCollection` + `set_array()`, label `\"\"` | Picks up scalar-mapped collection, shows colormap controls |\n",
-    "\n",
-    "**Install:**\n",
-    "```bash\n",
-    "pip install mplstudio scanpy\n",
-    "```\n",
-    "\n",
-    "The notebook runs fine without scanpy too — it falls back to synthetic data that reproduces the same matplotlib patterns."
-   ]
+   "source": "# mplstudio × scanpy\n\nmplstudio detects the two most common scanpy plot styles and adds a **`palette=`** kwarg to carry scanpy's colour assignments directly into the GUI.\n\n| Pattern | What scanpy does | What mplstudio does |\n|---|---|---|\n| Categorical UMAP | One `PathCollection` per category, no `ax.legend()` | Detects unlabeled collections, falls back to direct scan |\n| Continuous UMAP | Single `PathCollection` + `set_array()`, label `\"\"` | Picks up scalar-mapped collection, shows colormap controls |\n\n**Install:**\n```bash\npip install mplstudio scanpy\n```"
   },
   {
    "cell_type": "code",
@@ -28,19 +12,7 @@
    "id": "b2c3d4e5",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import mplstudio\n",
-    "\n",
-    "try:\n",
-    "    import scanpy as sc\n",
-    "    HAS_SCANPY = True\n",
-    "    print(f\"scanpy {sc.__version__} found — using real AnnData\")\n",
-    "except ImportError:\n",
-    "    HAS_SCANPY = False\n",
-    "    print(\"scanpy not installed — using synthetic data that mirrors scanpy's matplotlib output\")"
-   ]
+   "source": "import numpy as np\nimport matplotlib.pyplot as plt\nimport scanpy as sc\nimport mplstudio\n\nprint(f\"scanpy {sc.__version__}\")"
   },
   {
    "cell_type": "markdown",
@@ -59,55 +31,7 @@
    "id": "d4e5f6a7",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Palette that mirrors what would live in adata.uns[\"cell_type_colors\"]\n",
-    "CELL_TYPE_COLORS = {\n",
-    "    \"T cell\":    \"#e41a1c\",\n",
-    "    \"B cell\":    \"#377eb8\",\n",
-    "    \"NK cell\":   \"#4daf4a\",\n",
-    "    \"Monocyte\":  \"#ff7f00\",\n",
-    "    \"DC\":        \"#984ea3\",\n",
-    "}\n",
-    "\n",
-    "if HAS_SCANPY:\n",
-    "    # ── real scanpy path ──────────────────────────────────────────────────\n",
-    "    adata = sc.datasets.pbmc68k_reduced()\n",
-    "    sc.pp.neighbors(adata)\n",
-    "    sc.tl.umap(adata)\n",
-    "\n",
-    "    fig_cat, ax_cat = plt.subplots(figsize=(5, 4))\n",
-    "    sc.pl.umap(adata, color=\"bulk_labels\", ax=ax_cat, show=False)\n",
-    "    # adata.uns[\"bulk_labels_colors\"] holds the per-category hex strings\n",
-    "    palette = dict(zip(\n",
-    "        adata.obs[\"bulk_labels\"].cat.categories,\n",
-    "        adata.uns[\"bulk_labels_colors\"],\n",
-    "    ))\n",
-    "    plt.close()\n",
-    "\n",
-    "else:\n",
-    "    # ── synthetic fallback: same matplotlib structure as scanpy ───────────\n",
-    "    rng = np.random.default_rng(0)\n",
-    "\n",
-    "    # Simulate UMAP 2-D embedding per cell type\n",
-    "    centres = {\"T cell\": (2, 1), \"B cell\": (-2, 1), \"NK cell\": (0, -2),\n",
-    "               \"Monocyte\": (2, -1), \"DC\": (-2, -1)}\n",
-    "\n",
-    "    fig_cat, ax_cat = plt.subplots(figsize=(5, 4))\n",
-    "    for ct, (cx, cy) in centres.items():\n",
-    "        xy = rng.standard_normal((80, 2)) * 0.6 + [cx, cy]\n",
-    "        # scanpy: one PathCollection per category, label=category name\n",
-    "        ax_cat.scatter(xy[:, 0], xy[:, 1],\n",
-    "                       c=CELL_TYPE_COLORS[ct], label=ct, s=8, alpha=0.85)\n",
-    "    # scanpy does NOT call ax.legend() here\n",
-    "    ax_cat.set_xlabel(\"UMAP1\")\n",
-    "    ax_cat.set_ylabel(\"UMAP2\")\n",
-    "    ax_cat.set_title(\"UMAP — cell type (synthetic)\")\n",
-    "    plt.close()\n",
-    "\n",
-    "    palette = CELL_TYPE_COLORS.copy()\n",
-    "\n",
-    "print(\"Palette:\", palette)"
-   ]
+   "source": "adata = sc.datasets.pbmc68k_reduced()\nsc.pp.neighbors(adata)\nsc.tl.umap(adata)\n\n# palette dict — same structure as adata.uns[\"cell_type_colors\"]\npalette = dict(zip(\n    adata.obs[\"bulk_labels\"].cat.categories,\n    adata.uns[\"bulk_labels_colors\"],\n))\nprint(\"Cell types:\", list(palette.keys()))"
   },
   {
    "cell_type": "code",
@@ -115,11 +39,7 @@
    "id": "e5f6a7b8",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Pass the palette so mplstudio shows a \"Custom\" colour mode\n",
-    "# that pre-fills each category with its original scanpy colour.\n",
-    "mplstudio.studio(fig_cat, palette=palette)"
-   ]
+   "source": "fig_cat, ax_cat = plt.subplots(figsize=(5, 4))\nsc.pl.umap(adata, color=\"bulk_labels\", ax=ax_cat, show=False)\nplt.close()\n\n# palette= kwarg → Colors section shows a \"Custom\" mode\nmplstudio.studio(fig_cat, palette=palette)"
   },
   {
    "cell_type": "markdown",
@@ -152,7 +72,7 @@
    "id": "b8c9d0e1",
    "metadata": {},
    "outputs": [],
-   "source": "if HAS_SCANPY:\n    fig_cont, ax_cont = plt.subplots(figsize=(5, 4))\n    gene = adata.var_names[0]  # first gene\n    sc.pl.umap(adata, color=gene, ax=ax_cont, show=False)\n    plt.close()\n\nelse:\n    rng2 = np.random.default_rng(1)\n    n = 400\n    angle = rng2.uniform(0, 2 * np.pi, n)\n    radius = rng2.uniform(0, 3, n)\n    x = radius * np.cos(angle)\n    y = radius * np.sin(angle)\n    # Gene expression: higher near the centre\n    expr = np.exp(-radius / 1.5) + rng2.standard_normal(n) * 0.05\n    expr = np.clip(expr, 0, None)\n\n    fig_cont, ax_cont = plt.subplots(figsize=(5, 4))\n    # scanpy: single scatter, label=\"\", c=array via set_array internally\n    scat = ax_cont.scatter(x, y, c=expr, cmap=\"viridis\", s=8, vmin=0)\n    fig_cont.colorbar(scat, ax=ax_cont, label=\"expr (log-norm)\")\n    ax_cont.set_xlabel(\"UMAP1\")\n    ax_cont.set_ylabel(\"UMAP2\")\n    ax_cont.set_title(\"UMAP — gene expression (synthetic)\")\n    plt.close()\n\nmplstudio.studio(fig_cont)"
+   "source": "gene = adata.var_names[0]\nfig_cont, ax_cont = plt.subplots(figsize=(5, 4))\nsc.pl.umap(adata, color=gene, ax=ax_cont, show=False)\nplt.close()\n\nmplstudio.studio(fig_cont)"
   },
   {
    "cell_type": "markdown",
@@ -175,7 +95,7 @@
   {
    "cell_type": "code",
    "id": "308cf287",
-   "source": "MARKER_GENES = {\n    \"T cell\":   [\"CD3D\", \"CD3E\", \"CD8A\"],\n    \"B cell\":   [\"CD79A\", \"MS4A1\", \"CD19\"],\n    \"NK cell\":  [\"GNLY\", \"NKG7\", \"KLRD1\"],\n    \"Monocyte\": [\"LYZ\", \"CST3\", \"CD14\"],\n    \"DC\":       [\"FCER1A\", \"CST7\", \"CLEC9A\"],\n}\nCELL_TYPES = list(MARKER_GENES)\nGENES      = [g for gs in MARKER_GENES.values() for g in gs]\n\nif HAS_SCANPY:\n    # sc.pl.heatmap returns a dict of axes; the main heatmap axes contains an AxesImage\n    axes_dict = sc.pl.heatmap(\n        adata,\n        var_names=adata.var_names[:12],\n        groupby=\"bulk_labels\",\n        show=False,\n    )\n    fig_hm = axes_dict[\"heatmap_ax\"].get_figure()\n    plt.close()\n\nelse:\n    # Synthetic: mean log-normalised expression per cell type per gene\n    rng5 = np.random.default_rng(5)\n    # Base expression matrix: rows = cell types, cols = genes\n    base = np.zeros((len(CELL_TYPES), len(GENES)))\n    for i, ct in enumerate(CELL_TYPES):\n        for j, gene in enumerate(GENES):\n            # high if gene is a marker for this cell type\n            base[i, j] = 2.5 if gene in MARKER_GENES[ct] else 0.2\n    expr_matrix = (base + rng5.exponential(0.3, base.shape)).T  # genes × cell_types\n\n    fig_hm, ax_hm = plt.subplots(figsize=(6, 5))\n    im = ax_hm.imshow(expr_matrix, aspect=\"auto\", cmap=\"Reds\", vmin=0)\n    fig_hm.colorbar(im, ax=ax_hm, label=\"Mean expression (log-norm)\")\n    ax_hm.set_xticks(range(len(CELL_TYPES)))\n    ax_hm.set_xticklabels(CELL_TYPES, rotation=35, ha=\"right\", fontsize=9)\n    ax_hm.set_yticks(range(len(GENES)))\n    ax_hm.set_yticklabels(GENES, fontsize=8)\n    ax_hm.set_title(\"Marker gene expression per cell type\")\n    plt.tight_layout()\n    plt.close()\n\nmplstudio.studio(fig_hm)",
+   "source": "marker_genes = {\n    \"CD14+ Monocyte\":    [\"LYZ\", \"CST3\", \"CD14\"],\n    \"CD19+ B\":           [\"CD79A\", \"MS4A1\"],\n    \"CD4+/CD25 T Reg\":  [\"IL2RA\", \"FOXP3\"],\n    \"CD4+/CD45RA+/CD25- Naive T\": [\"CCR7\", \"SELL\"],\n    \"NK cell\":           [\"GNLY\", \"NKG7\"],\n}\n# Only use genes present in adata\nvalid = {ct: [g for g in gs if g in adata.var_names]\n         for ct, gs in marker_genes.items()}\nplot_genes = [g for gs in valid.values() for g in gs][:12]\n\naxes_dict = sc.pl.heatmap(\n    adata, var_names=plot_genes, groupby=\"bulk_labels\", show=False\n)\nfig_hm = axes_dict[\"heatmap_ax\"].get_figure()\nplt.close()\n\nmplstudio.studio(fig_hm)",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -195,7 +115,7 @@
   {
    "cell_type": "code",
    "id": "f0e24d38",
-   "source": "VIOLIN_GENES = [\"CD3D\", \"CD79A\", \"LYZ\"]  # T cell, B cell, Monocyte markers\n\nif HAS_SCANPY:\n    fig_vn, axes_vn = plt.subplots(1, len(VIOLIN_GENES), figsize=(9, 3), sharey=False)\n    for ax_v, gene in zip(axes_vn, VIOLIN_GENES):\n        sc.pl.violin(adata, keys=gene, groupby=\"bulk_labels\",\n                     ax=ax_v, show=False, rotation=35)\n    fig_vn.suptitle(\"Marker gene expression by cell type\")\n    plt.tight_layout()\n    plt.close()\n\nelse:\n    rng6 = np.random.default_rng(6)\n\n    # Simulate per-cell expression for 3 marker genes across 5 cell types\n    # Each gene is highly expressed in its cognate cell type\n    COGNATE = {\"CD3D\": \"T cell\", \"CD79A\": \"B cell\", \"LYZ\": \"Monocyte\"}\n    N_CELLS = 120  # per cell type\n\n    fig_vn, axes_vn = plt.subplots(1, len(VIOLIN_GENES), figsize=(9, 3), sharey=False)\n    for ax_v, gene in zip(axes_vn, VIOLIN_GENES):\n        all_data, all_pos, tick_labels = [], [], []\n        for k, ct in enumerate(CELL_TYPES):\n            high = (ct == COGNATE[gene])\n            mu  = rng6.uniform(1.8, 2.5) if high else rng6.uniform(0.0, 0.4)\n            sig = 0.4 if high else 0.3\n            vals = np.clip(rng6.normal(mu, sig, N_CELLS), 0, None)\n            all_data.append(vals)\n            tick_labels.append(ct)\n\n        # violinplot + strip-chart (same structure as scanpy)\n        parts = ax_v.violinplot(all_data, positions=range(len(CELL_TYPES)),\n                                showmedians=True, showextrema=False, widths=0.7)\n        for k, vals in enumerate(all_data):\n            jitter = rng6.uniform(-0.12, 0.12, len(vals))\n            ax_v.scatter(k + jitter, vals, s=2, alpha=0.3,\n                         color=\"#555555\", zorder=3)\n        # apply palette colours to violin bodies\n        for body, ct in zip(parts[\"bodies\"], CELL_TYPES):\n            body.set_facecolor(CELL_TYPE_COLORS[ct])\n            body.set_alpha(0.75)\n\n        ax_v.set_title(gene, fontsize=10)\n        ax_v.set_xticks(range(len(CELL_TYPES)))\n        ax_v.set_xticklabels(tick_labels, rotation=35, ha=\"right\", fontsize=8)\n        ax_v.set_ylabel(\"Expression\" if ax_v is axes_vn[0] else \"\")\n\n    fig_vn.suptitle(\"Marker gene expression by cell type\")\n    plt.tight_layout()\n    plt.close()\n\nmplstudio.studio(fig_vn)",
+   "source": "violin_genes = [g for g in [\"LYZ\", \"NKG7\", \"CD79A\"] if g in adata.var_names]\n\nfig_vn, axes_vn = plt.subplots(1, len(violin_genes), figsize=(9, 3), sharey=False)\nfor ax_v, gene in zip(np.atleast_1d(axes_vn), violin_genes):\n    sc.pl.violin(adata, keys=gene, groupby=\"bulk_labels\",\n                 ax=ax_v, show=False, rotation=35)\nfig_vn.suptitle(\"Marker gene expression by cell type\", y=1.02)\nplt.tight_layout()\nplt.close()\n\nmplstudio.studio(fig_vn)",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/examples/scanpy_umap.ipynb
+++ b/examples/scanpy_umap.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# mplstudio × scanpy\n",
+    "\n",
+    "mplstudio detects the two most common scanpy plot styles and adds a **`palette=`** kwarg to carry scanpy's colour assignments directly into the GUI.\n",
+    "\n",
+    "| Pattern | What scanpy does | What mplstudio does |\n",
+    "|---|---|---|\n",
+    "| Categorical UMAP | One `PathCollection` per category, no `ax.legend()` | Detects unlabeled collections, falls back to direct scan |\n",
+    "| Continuous UMAP | Single `PathCollection` + `set_array()`, label `\"\"` | Picks up scalar-mapped collection, shows colormap controls |\n",
+    "\n",
+    "**Install:**\n",
+    "```bash\n",
+    "pip install mplstudio scanpy\n",
+    "```\n",
+    "\n",
+    "The notebook runs fine without scanpy too — it falls back to synthetic data that reproduces the same matplotlib patterns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import mplstudio\n",
+    "\n",
+    "try:\n",
+    "    import scanpy as sc\n",
+    "    HAS_SCANPY = True\n",
+    "    print(f\"scanpy {sc.__version__} found — using real AnnData\")\n",
+    "except ImportError:\n",
+    "    HAS_SCANPY = False\n",
+    "    print(\"scanpy not installed — using synthetic data that mirrors scanpy's matplotlib output\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "## 1. Categorical UMAP\n",
+    "\n",
+    "Scanpy draws one `PathCollection` per category and no `ax.legend()` (it renders its own external legend via `AnchoredOffsetbox`).  \n",
+    "mplstudio's fallback scan picks up all labeled collections automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Palette that mirrors what would live in adata.uns[\"cell_type_colors\"]\n",
+    "CELL_TYPE_COLORS = {\n",
+    "    \"T cell\":    \"#e41a1c\",\n",
+    "    \"B cell\":    \"#377eb8\",\n",
+    "    \"NK cell\":   \"#4daf4a\",\n",
+    "    \"Monocyte\":  \"#ff7f00\",\n",
+    "    \"DC\":        \"#984ea3\",\n",
+    "}\n",
+    "\n",
+    "if HAS_SCANPY:\n",
+    "    # ── real scanpy path ──────────────────────────────────────────────────\n",
+    "    adata = sc.datasets.pbmc68k_reduced()\n",
+    "    sc.pp.neighbors(adata)\n",
+    "    sc.tl.umap(adata)\n",
+    "\n",
+    "    fig_cat, ax_cat = plt.subplots(figsize=(5, 4))\n",
+    "    sc.pl.umap(adata, color=\"bulk_labels\", ax=ax_cat, show=False)\n",
+    "    # adata.uns[\"bulk_labels_colors\"] holds the per-category hex strings\n",
+    "    palette = dict(zip(\n",
+    "        adata.obs[\"bulk_labels\"].cat.categories,\n",
+    "        adata.uns[\"bulk_labels_colors\"],\n",
+    "    ))\n",
+    "    plt.close()\n",
+    "\n",
+    "else:\n",
+    "    # ── synthetic fallback: same matplotlib structure as scanpy ───────────\n",
+    "    rng = np.random.default_rng(0)\n",
+    "\n",
+    "    # Simulate UMAP 2-D embedding per cell type\n",
+    "    centres = {\"T cell\": (2, 1), \"B cell\": (-2, 1), \"NK cell\": (0, -2),\n",
+    "               \"Monocyte\": (2, -1), \"DC\": (-2, -1)}\n",
+    "\n",
+    "    fig_cat, ax_cat = plt.subplots(figsize=(5, 4))\n",
+    "    for ct, (cx, cy) in centres.items():\n",
+    "        xy = rng.standard_normal((80, 2)) * 0.6 + [cx, cy]\n",
+    "        # scanpy: one PathCollection per category, label=category name\n",
+    "        ax_cat.scatter(xy[:, 0], xy[:, 1],\n",
+    "                       c=CELL_TYPE_COLORS[ct], label=ct, s=8, alpha=0.85)\n",
+    "    # scanpy does NOT call ax.legend() here\n",
+    "    ax_cat.set_xlabel(\"UMAP1\")\n",
+    "    ax_cat.set_ylabel(\"UMAP2\")\n",
+    "    ax_cat.set_title(\"UMAP — cell type (synthetic)\")\n",
+    "    plt.close()\n",
+    "\n",
+    "    palette = CELL_TYPE_COLORS.copy()\n",
+    "\n",
+    "print(\"Palette:\", palette)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pass the palette so mplstudio shows a \"Custom\" colour mode\n",
+    "# that pre-fills each category with its original scanpy colour.\n",
+    "mplstudio.studio(fig_cat, palette=palette)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "source": [
+    "**What to try in the panel:**\n",
+    "\n",
+    "- **Colors → Custom**: restores the original scanpy palette at any time.\n",
+    "- **Colors → Manual**: individual pickers are pre-filled from the palette — tweak single categories.\n",
+    "- **Colors → Palette / Smart**: switch to a built-in palette or a perceptually-uniform auto palette.\n",
+    "- **Typography**: adjust font size and family for axis labels / title.\n",
+    "- **Axes**: tighten axis limits or add/remove grid."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "source": [
+    "## 2. Continuous UMAP (gene expression)\n",
+    "\n",
+    "Scanpy plots gene expression as a single `PathCollection` with `set_array()` (per-cell values) and label `\"\"`.  \n",
+    "mplstudio detects this as a *continuous* plot and shows the colormap picker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "outputs": [],
+   "source": "if HAS_SCANPY:\n    fig_cont, ax_cont = plt.subplots(figsize=(5, 4))\n    gene = adata.var_names[0]  # first gene\n    sc.pl.umap(adata, color=gene, ax=ax_cont, show=False)\n    plt.close()\n\nelse:\n    rng2 = np.random.default_rng(1)\n    n = 400\n    angle = rng2.uniform(0, 2 * np.pi, n)\n    radius = rng2.uniform(0, 3, n)\n    x = radius * np.cos(angle)\n    y = radius * np.sin(angle)\n    # Gene expression: higher near the centre\n    expr = np.exp(-radius / 1.5) + rng2.standard_normal(n) * 0.05\n    expr = np.clip(expr, 0, None)\n\n    fig_cont, ax_cont = plt.subplots(figsize=(5, 4))\n    # scanpy: single scatter, label=\"\", c=array via set_array internally\n    scat = ax_cont.scatter(x, y, c=expr, cmap=\"viridis\", s=8, vmin=0)\n    fig_cont.colorbar(scat, ax=ax_cont, label=\"expr (log-norm)\")\n    ax_cont.set_xlabel(\"UMAP1\")\n    ax_cont.set_ylabel(\"UMAP2\")\n    ax_cont.set_title(\"UMAP — gene expression (synthetic)\")\n    plt.close()\n\nmplstudio.studio(fig_cont)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "**What to try:**\n",
+    "\n",
+    "- **Colors → Sequential**: swap `viridis` for `plasma`, `inferno`, or `magma`.\n",
+    "- **Colors → Diverging**: try `RdBu_r` or `coolwarm` to highlight cells above / below the mean.\n",
+    "- **Save**: export a publication-ready PNG at 300 dpi."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "## 3. Mixed figure — categorical overlay on continuous background\n",
+    "\n",
+    "Sometimes you want to overlay labelled scatter groups on top of a density contour or heatmap.  \n",
+    "mplstudio detects **both** and shows the full palette + colormap controls together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng3 = np.random.default_rng(2)\n",
+    "\n",
+    "# Continuous background: 2-D KDE-like density (contourf)\n",
+    "xg = np.linspace(-4, 4, 80)\n",
+    "yg = np.linspace(-4, 4, 80)\n",
+    "Xg, Yg = np.meshgrid(xg, yg)\n",
+    "density = (\n",
+    "    np.exp(-((Xg - 1.5)**2 + (Yg - 1.0)**2) / 2.5) +\n",
+    "    np.exp(-((Xg + 1.5)**2 + (Yg - 0.5)**2) / 2.0) * 0.7\n",
+    ")\n",
+    "\n",
+    "fig_mix, ax_mix = plt.subplots(figsize=(5, 4))\n",
+    "cf = ax_mix.contourf(Xg, Yg, density, levels=10, cmap=\"Blues\", alpha=0.6)\n",
+    "fig_mix.colorbar(cf, ax=ax_mix, label=\"cell density\")\n",
+    "\n",
+    "# Categorical overlay: two annotated populations\n",
+    "for name, cx, cy, col in [(\"Pop A\", 1.5, 1.0, \"#E69F00\"),\n",
+    "                           (\"Pop B\", -1.5, 0.5, \"#56B4E9\")]:\n",
+    "    xy = rng3.standard_normal((50, 2)) * 0.5 + [cx, cy]\n",
+    "    ax_mix.scatter(xy[:, 0], xy[:, 1], label=name, color=col,\n",
+    "                   edgecolors=\"white\", linewidths=0.4, s=30)\n",
+    "ax_mix.legend()\n",
+    "ax_mix.set_title(\"Density + categorical overlay\")\n",
+    "ax_mix.set_xlabel(\"UMAP1\")\n",
+    "ax_mix.set_ylabel(\"UMAP2\")\n",
+    "plt.close()\n",
+    "\n",
+    "mplstudio.studio(fig_mix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "## 4. Programmatic style API (no GUI)\n",
+    "\n",
+    "All style functions are accessible directly from `mplstudio.style` — useful for scripted figure generation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mplstudio import style as S\n",
+    "\n",
+    "# Rebuild the categorical figure and apply scanpy palette programmatically\n",
+    "rng4 = np.random.default_rng(0)\n",
+    "centres = {\"T cell\": (2, 1), \"B cell\": (-2, 1), \"NK cell\": (0, -2),\n",
+    "           \"Monocyte\": (2, -1), \"DC\": (-2, -1)}\n",
+    "\n",
+    "fig_api, ax_api = plt.subplots(figsize=(5, 4))\n",
+    "for ct, (cx, cy) in centres.items():\n",
+    "    xy = rng4.standard_normal((80, 2)) * 0.6 + [cx, cy]\n",
+    "    ax_api.scatter(xy[:, 0], xy[:, 1], label=ct, s=8, alpha=0.85)\n",
+    "ax_api.set_title(\"Before styling\")\n",
+    "\n",
+    "# Apply scanpy palette via the style API\n",
+    "labels  = S.get_line_labels(fig_api)\n",
+    "colors  = [CELL_TYPE_COLORS.get(lbl, \"#888888\") for lbl in labels]\n",
+    "S.set_line_colors_manual(fig_api, colors)\n",
+    "S.set_font_size(fig_api, 12)\n",
+    "S.set_spine_style(fig_api, \"2-Side\")\n",
+    "\n",
+    "ax_api.set_title(\"After styling\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mplstudio/style/__init__.py
+++ b/mplstudio/style/__init__.py
@@ -28,6 +28,7 @@ from ._legend import (
     LEGEND_LOCATIONS,
 )
 from ._grid_spines import set_grid, set_spine_style, SPINE_STYLES
+from ._ticks import set_tick_labels_visible, set_xtick_rotation, set_tick_interval
 
 __all__ = [
     # figure
@@ -47,4 +48,6 @@ __all__ = [
     "set_legend_title", "LEGEND_LOCATIONS",
     # grid & spines
     "set_grid", "set_spine_style", "SPINE_STYLES",
+    # ticks
+    "set_tick_labels_visible", "set_xtick_rotation", "set_tick_interval",
 ]

--- a/mplstudio/style/_artists.py
+++ b/mplstudio/style/_artists.py
@@ -65,8 +65,14 @@ def _set_artist_color(artist, color: str) -> None:
     if isinstance(artist, Line2D):
         artist.set_color(color)
     elif isinstance(artist, PathCollection):
-        artist.set_facecolor(color)
-        artist.set_edgecolor(color)
+        # Preserve the existing facecolor alpha (scatter alpha lives in RGBA channel)
+        fc = artist.get_facecolor()
+        alpha = float(fc[0, 3]) if len(fc) else 1.0
+        artist.set_facecolor((*mcolors.to_rgb(color), alpha))
+        # Only sync edge colour if edges were originally visible
+        ec = artist.get_edgecolor()
+        if len(ec) and ec[0, 3] > 0.01:
+            artist.set_edgecolor((*mcolors.to_rgb(color), float(ec[0, 3])))
 
 
 def _sync_legend_colors(ax) -> None:

--- a/mplstudio/style/_artists.py
+++ b/mplstudio/style/_artists.py
@@ -8,34 +8,47 @@ from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 
 
+_UNLABELED = {"", "_nolegend_"}
+
+
 def _continuous_artists(fig: Figure):
-    """Yield artists that carry a scalar colormap (AxesImage, QuadMesh, etc.)."""
+    """Yield artists that carry a scalar colormap (AxesImage, QuadMesh, etc.).
+
+    Covers scanpy continuous UMAP where a PathCollection uses set_array() for
+    per-point values and has an empty or _nolegend_ label.
+    """
     for ax in fig.axes:
         for img in ax.get_images():
             yield img
         for coll in ax.collections:
             lbl = getattr(coll, "get_label", lambda: "_")()
-            # Unlabeled collections with scalar data → continuous (pcolormesh, contourf…)
-            if lbl.startswith("_") and hasattr(coll, "get_array") and coll.get_array() is not None:
+            has_scalar = hasattr(coll, "get_array") and coll.get_array() is not None
+            if has_scalar and (lbl.startswith("_") or lbl in _UNLABELED):
                 yield coll
 
 
 def _labeled_artists(ax):
     """Yield (actual_artist, label) for every legend-visible series, in legend order.
 
-    Works for both Line2D (line plots) and PathCollection (scatter plots).
-    Matches legend labels to actual axes artists so both can be coloured.
+    Works for Line2D (line plots) and PathCollection (scatter plots), including
+    scanpy categorical UMAP where each category is a separate PathCollection.
+    Falls back to direct collection scan when no legend exists.
     """
     handles, labels = ax.get_legend_handles_labels()
-    # Build label→actual-artist lookup (first occurrence wins)
     candidates: dict[str, object] = {}
     for a in (*ax.get_lines(), *ax.collections):
         lbl = a.get_label()
-        if lbl and not lbl.startswith("_") and lbl not in candidates:
+        if lbl and not lbl.startswith("_") and lbl not in _UNLABELED and lbl not in candidates:
             candidates[lbl] = a
-    for _, label in zip(handles, labels):
-        if label in candidates:
-            yield candidates[label], label
+
+    if handles:
+        for _, label in zip(handles, labels):
+            if label in candidates:
+                yield candidates[label], label
+    else:
+        # No legend (e.g. scanpy without legend_loc): yield in artist order
+        for lbl, artist in candidates.items():
+            yield artist, lbl
 
 
 def _get_artist_color(artist) -> str:

--- a/mplstudio/style/_opacity.py
+++ b/mplstudio/style/_opacity.py
@@ -2,9 +2,40 @@
 
 from __future__ import annotations
 
+from matplotlib.collections import PathCollection
 from matplotlib.figure import Figure
 
 from ._artists import _labeled_artists
+
+
+def _get_artist_alpha(artist) -> float:
+    """Return effective alpha for an artist.
+
+    For PathCollection, alpha is stored in the facecolor RGBA channel (set by
+    scatter's alpha= kwarg).  The artist-level alpha (get_alpha()) may ALSO be
+    set to the same value, which would cause double-multiplication during
+    rendering.  We use the facecolor channel as the single source of truth.
+    """
+    if isinstance(artist, PathCollection):
+        fc = artist.get_facecolor()
+        return float(fc[0, 3]) if len(fc) else 1.0
+    return 1.0 if artist.get_alpha() is None else float(artist.get_alpha())
+
+
+def _set_artist_alpha(artist, alpha: float) -> None:
+    """Set alpha without double-multiplication for PathCollection artists."""
+    if isinstance(artist, PathCollection):
+        # Drive opacity via the facecolor RGBA channel; clear artist-level alpha
+        fc = artist.get_facecolor().copy()
+        fc[:, 3] = alpha
+        artist.set_facecolor(fc)
+        ec = artist.get_edgecolor().copy()
+        if len(ec) and ec[0, 3] > 0.01:  # only update visible edges
+            ec[:, 3] = alpha
+            artist.set_edgecolor(ec)
+        artist.set_alpha(None)            # prevent double-alpha multiplication
+    else:
+        artist.set_alpha(alpha)
 
 
 def set_series_alpha(fig: Figure, alphas: list[float]) -> None:
@@ -13,13 +44,13 @@ def set_series_alpha(fig: Figure, alphas: list[float]) -> None:
     for ax in fig.axes:
         for artist, _ in _labeled_artists(ax):
             if idx < len(alphas):
-                artist.set_alpha(float(alphas[idx]))
+                _set_artist_alpha(artist, float(alphas[idx]))
             idx += 1
 
 
 def get_series_alpha(fig: Figure) -> list[float]:
     return [
-        1.0 if artist.get_alpha() is None else float(artist.get_alpha())
+        _get_artist_alpha(artist)
         for ax in fig.axes
         for artist, _ in _labeled_artists(ax)
     ]

--- a/mplstudio/style/_ticks.py
+++ b/mplstudio/style/_ticks.py
@@ -1,0 +1,49 @@
+"""Tick label and locator style functions."""
+
+from __future__ import annotations
+
+import matplotlib.ticker as ticker
+from matplotlib.figure import Figure
+
+
+def set_tick_labels_visible(
+    fig: Figure, x: bool = True, y: bool = True, ax_idx: int = 0
+) -> None:
+    """Show or hide x/y tick labels for the given axes."""
+    if ax_idx >= len(fig.axes):
+        return
+    ax = fig.axes[ax_idx]
+    ax.tick_params(axis="x", labelbottom=x, labeltop=False)
+    ax.tick_params(axis="y", labelleft=y, labelright=False)
+
+
+def set_xtick_rotation(fig: Figure, rotation: float, ax_idx: int = 0) -> None:
+    """Rotate x-axis tick labels; set ha='right' when rotated."""
+    if ax_idx >= len(fig.axes):
+        return
+    ha = "right" if rotation > 0 else "center"
+    for label in fig.axes[ax_idx].get_xticklabels():
+        label.set_rotation(rotation)
+        label.set_ha(ha)
+    # Also apply to future ticks via tick_params
+    fig.axes[ax_idx].tick_params(axis="x", labelrotation=rotation)
+
+
+def set_tick_interval(
+    fig: Figure,
+    x_interval: float | None,
+    y_interval: float | None,
+    ax_idx: int = 0,
+) -> None:
+    """Set major tick spacing; 0 or None resets to AutoLocator."""
+    if ax_idx >= len(fig.axes):
+        return
+    ax = fig.axes[ax_idx]
+    if x_interval:
+        ax.xaxis.set_major_locator(ticker.MultipleLocator(x_interval))
+    else:
+        ax.xaxis.set_major_locator(ticker.AutoLocator())
+    if y_interval:
+        ax.yaxis.set_major_locator(ticker.MultipleLocator(y_interval))
+    else:
+        ax.yaxis.set_major_locator(ticker.AutoLocator())

--- a/mplstudio/widget/_constants.py
+++ b/mplstudio/widget/_constants.py
@@ -4,7 +4,7 @@ _PREVIEW_HEIGHT = 400
 
 _KNOWN_SECTIONS = frozenset({
     "figure_size", "typography", "colors", "alpha",
-    "axes", "legend", "grid_spines", "palette_suggestions", "save",
+    "axes", "ticks", "legend", "grid_spines", "palette_suggestions", "save",
 })
 
 _GITHUB_ISSUES = "https://github.com/symoon9/mplstudio/issues"

--- a/mplstudio/widget/_ctx.py
+++ b/mplstudio/widget/_ctx.py
@@ -19,6 +19,7 @@ class _PanelCtx:
     pid: str
     dark: bool
     refresh: Callable[[], None]
+    palette: dict | None = None                          # {label: hex} e.g. from adata.uns
     ax_idx: list = field(default_factory=lambda: [0])   # [int]
     fb: list = field(default_factory=lambda: [False])   # font busy guard
     ab: list = field(default_factory=lambda: [False])   # alpha busy guard

--- a/mplstudio/widget/_sections/colors.py
+++ b/mplstudio/widget/_sections/colors.py
@@ -25,8 +25,12 @@ def build(ctx: _PanelCtx) -> widgets.VBox:
     cat_box_children: list[widgets.Widget] = []
 
     if plot_type in ("categorical", "mixed"):
+        _has_palette = ctx.palette is not None
+        _mode_options = ["Palette", "Manual", "Smart"]
+        if _has_palette:
+            _mode_options = ["Custom"] + _mode_options
         color_mode = widgets.ToggleButtons(
-            options=["Palette", "Manual", "Smart"], value="Palette",
+            options=_mode_options, value=_mode_options[0],
             description="Mode:", style={"button_width": "62px"},
             layout=widgets.Layout(width="100%", margin="4px 4px"))
 
@@ -39,12 +43,20 @@ def build(ctx: _PanelCtx) -> widgets.VBox:
         palette_preview_w = _build_palette_preview(_pal_names[0])
         palette_col = widgets.VBox([palette_select, palette_preview_w],
                                    layout=widgets.Layout(width="95%"))
+        palette_col.layout.display = "none" if _has_palette else ""
 
         line_colors = S.get_line_colors(ctx.fig)
         line_labels = S.get_line_labels(ctx.fig)
+
+        # Pre-fill Manual pickers from ctx.palette when available
+        def _picker_color(lbl: str, default: str) -> str:
+            if ctx.palette and lbl in ctx.palette:
+                return ctx.palette[lbl]
+            return default
+
         manual_pickers = [
             widgets.ColorPicker(
-                value=c,
+                value=_picker_color(lbl, c),
                 description=(lbl[:13] + "…" if len(lbl) > 13 else lbl),
                 style={"description_width": "82px"}, concise=False,
                 layout=widgets.Layout(width="90%"))
@@ -64,9 +76,23 @@ def build(ctx: _PanelCtx) -> widgets.VBox:
                                      layout=widgets.Layout(width="100%"))
         smart_section.layout.display = "none"
 
+        # Custom section: read-only swatches from ctx.palette
+        if _has_palette:
+            _custom_colors = [ctx.palette.get(lbl, c) for c, lbl in zip(line_colors, line_labels)]
+            custom_section = widgets.VBox(
+                [widgets.HTML(_swatches_div(_custom_colors))] if _custom_colors
+                else [widgets.HTML("<i style='color:#888'>No matching labels.</i>")],
+                layout=widgets.Layout(width="100%"))
+        else:
+            custom_section = widgets.VBox([])
+            custom_section.layout.display = "none"
+
         def _apply_colors():
             m = color_mode.value
-            if m == "Manual":
+            if m == "Custom":
+                S.set_line_colors_manual(ctx.fig, [ctx.palette.get(lbl, c)
+                                                    for c, lbl in zip(line_colors, line_labels)])
+            elif m == "Manual":
                 S.set_line_colors_manual(ctx.fig, [p.value for p in manual_pickers])
             elif m == "Smart":
                 S.set_line_colors_manual(ctx.fig, smart_palette(smart_n.value))
@@ -83,10 +109,13 @@ def build(ctx: _PanelCtx) -> widgets.VBox:
             _apply_colors()
 
         def _on_color_mode_change(c):
+            custom_section.layout.display = "none"
             palette_col.layout.display = "none"
             manual_section.layout.display = "none"
             smart_section.layout.display = "none"
-            if c["new"] == "Manual":
+            if c["new"] == "Custom":
+                custom_section.layout.display = ""
+            elif c["new"] == "Manual":
                 manual_section.layout.display = ""
             elif c["new"] == "Smart":
                 smart_section.layout.display = ""
@@ -100,7 +129,7 @@ def build(ctx: _PanelCtx) -> widgets.VBox:
         for p in manual_pickers:
             p.observe(lambda _: _apply_colors(), names="value")
 
-        cat_box_children = [color_mode, palette_col, manual_section, smart_section]
+        cat_box_children = [color_mode, custom_section, palette_col, manual_section, smart_section]
 
     cmap_box_children: list[widgets.Widget] = []
 

--- a/mplstudio/widget/_sections/colors.py
+++ b/mplstudio/widget/_sections/colors.py
@@ -26,7 +26,8 @@ def build(ctx: _PanelCtx) -> widgets.VBox:
 
     if plot_type in ("categorical", "mixed"):
         _has_palette = ctx.palette is not None
-        _mode_options = ["Palette", "Manual", "Smart"]
+        # Smart mode is kept in code but hidden from UI (#28)
+        _mode_options = ["Palette", "Manual"]
         if _has_palette:
             _mode_options = ["Custom"] + _mode_options
         color_mode = widgets.ToggleButtons(

--- a/mplstudio/widget/_sections/ticks.py
+++ b/mplstudio/widget/_sections/ticks.py
@@ -1,0 +1,111 @@
+"""Ticks section builder."""
+
+from __future__ import annotations
+
+import ipywidgets as widgets
+
+from .._ctx import _PanelCtx
+from .._helpers import _section, _mk_slider
+from ... import style as S
+
+
+def build(ctx: _PanelCtx) -> widgets.VBox | None:
+    if not ctx.fig.axes:
+        return None
+
+    def _cur_ax():
+        return ctx.fig.axes[ctx.ax_idx[0]]
+
+    # ── tick label visibility ─────────────────────────────────────────────
+    x_vis = widgets.ToggleButtons(
+        options=["On", "Off"],
+        value="On" if _cur_ax().get_xticklabels() else "Off",
+        description="X labels",
+        style={"button_width": "42px"},
+        layout=widgets.Layout(width="100%"),
+    )
+    y_vis = widgets.ToggleButtons(
+        options=["On", "Off"],
+        value="On" if _cur_ax().get_yticklabels() else "Off",
+        description="Y labels",
+        style={"button_width": "42px"},
+        layout=widgets.Layout(width="100%"),
+    )
+
+    # ── x-tick rotation ───────────────────────────────────────────────────
+    _init_rot = 0
+    xlabels = _cur_ax().get_xticklabels()
+    if xlabels:
+        _init_rot = int(xlabels[0].get_rotation())
+
+    x_rot = _mk_slider(
+        widgets.IntSlider, "X rotation", "68px",
+        value=_init_rot, min=0, max=90, step=15,
+    )
+
+    # ── tick intervals ────────────────────────────────────────────────────
+    interval_hdr = widgets.HTML(
+        "<span style='font-size:0.8em;font-weight:600;color:#555;"
+        "margin-top:6px;display:block'>Interval &nbsp;"
+        "<span style='font-weight:400'>(0 = auto)</span></span>"
+    )
+    x_interval = widgets.BoundedFloatText(
+        value=0.0, min=0.0, step=0.5,
+        description="X",
+        style={"description_width": "20px"},
+        layout=widgets.Layout(width="48%"),
+    )
+    y_interval = widgets.BoundedFloatText(
+        value=0.0, min=0.0, step=0.5,
+        description="Y",
+        style={"description_width": "20px"},
+        layout=widgets.Layout(width="48%"),
+    )
+    interval_row = widgets.HBox(
+        [x_interval, y_interval],
+        layout=widgets.Layout(width="100%", justify_content="space-between"),
+    )
+
+    # ── callbacks ─────────────────────────────────────────────────────────
+    def _on_x_vis(c):
+        S.set_tick_labels_visible(
+            ctx.fig,
+            x=(c["new"] == "On"),
+            y=(y_vis.value == "On"),
+            ax_idx=ctx.ax_idx[0],
+        )
+        ctx.refresh()
+
+    def _on_y_vis(c):
+        S.set_tick_labels_visible(
+            ctx.fig,
+            x=(x_vis.value == "On"),
+            y=(c["new"] == "On"),
+            ax_idx=ctx.ax_idx[0],
+        )
+        ctx.refresh()
+
+    def _on_x_rot(c):
+        S.set_xtick_rotation(ctx.fig, c["new"], ctx.ax_idx[0])
+        ctx.refresh()
+
+    def _on_interval(_):
+        S.set_tick_interval(
+            ctx.fig,
+            x_interval.value or None,
+            y_interval.value or None,
+            ctx.ax_idx[0],
+        )
+        ctx.refresh()
+
+    x_vis.observe(_on_x_vis, names="value")
+    y_vis.observe(_on_y_vis, names="value")
+    x_rot.observe(_on_x_rot, names="value")
+    x_interval.observe(_on_interval, names="value")
+    y_interval.observe(_on_interval, names="value")
+
+    return _section(
+        "Ticks", ctx.pid,
+        x_vis, x_rot, y_vis,
+        interval_hdr, interval_row,
+    )

--- a/mplstudio/widget/_studio.py
+++ b/mplstudio/widget/_studio.py
@@ -50,6 +50,7 @@ def studio(
     *,
     show: list[str] | None = None,
     dark: bool = False,
+    palette: dict[str, str] | None = None,
 ) -> None:
     """Display the mplstudio control panel.
 
@@ -61,6 +62,9 @@ def studio(
         Section names to display; ``None`` shows all.
     dark : bool
         Use Catppuccin Mocha dark theme (default: light/indigo).
+    palette : dict[str, str], optional
+        Label → hex color mapping (e.g. ``adata.uns["cell_type_colors"]``).
+        When provided, a "Custom" color mode is added to the Colors section.
     """
     if fig is None:
         fig = plt.gcf()
@@ -136,7 +140,7 @@ def studio(
     _refresh()
 
     # ── build shared context ──────────────────────────────────────────────
-    ctx = _PanelCtx(fig=fig, pid=_pid, dark=dark, refresh=_refresh)
+    ctx = _PanelCtx(fig=fig, pid=_pid, dark=dark, refresh=_refresh, palette=palette)
 
     # ── build sections ────────────────────────────────────────────────────
     sections: list[widgets.Widget] = []

--- a/mplstudio/widget/_studio.py
+++ b/mplstudio/widget/_studio.py
@@ -21,6 +21,7 @@ from ._sections import (
     colors as _sec_colors,
     opacity as _sec_opacity,
     axes as _sec_axes,
+    ticks as _sec_ticks,
     legend as _sec_legend,
     grid_spines as _sec_grid_spines,
     palette_suggestions as _sec_palette_suggestions,
@@ -36,6 +37,7 @@ _SECTION_BUILDERS = [
     ("colors",              _sec_colors),
     ("alpha",               _sec_opacity),
     ("axes",                _sec_axes),
+    ("ticks",               _sec_ticks),
     ("grid_spines",         _sec_grid_spines),
     ("palette_suggestions", _sec_palette_suggestions),
 ]

--- a/tests/test_scanpy_support.py
+++ b/tests/test_scanpy_support.py
@@ -1,0 +1,154 @@
+"""Tests for scanpy UMAP support — categorical and continuous plots."""
+
+import matplotlib
+matplotlib.use("Agg")
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import pytest
+
+from mplstudio import style as S
+from mplstudio.style._artists import _continuous_artists, _labeled_artists
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def categorical_umap_fig():
+    """Mimics scanpy pl.umap with a categorical obs column.
+
+    Each category is a separate PathCollection with no ax.legend() call
+    (scanpy draws its own legend via AnchoredOffsetbox).
+    """
+    f, ax = plt.subplots()
+    rng = np.random.default_rng(0)
+    categories = ["T cell", "B cell", "NK cell"]
+    colors = ["#e41a1c", "#377eb8", "#4daf4a"]
+    for cat, col in zip(categories, colors):
+        xy = rng.standard_normal((30, 2))
+        sc = ax.scatter(xy[:, 0], xy[:, 1], c=col, label=cat, s=10)
+    # No ax.legend() — scanpy draws its own legend externally
+    yield f
+    plt.close(f)
+
+
+@pytest.fixture
+def continuous_umap_fig():
+    """Mimics scanpy pl.umap with a continuous obs column (e.g. gene expression).
+
+    Single PathCollection with set_array() for per-point values and
+    label="" (default matplotlib label for unlabeled artists).
+    """
+    f, ax = plt.subplots()
+    rng = np.random.default_rng(1)
+    xy = rng.standard_normal((50, 2))
+    values = rng.random(50)
+    sc = ax.scatter(xy[:, 0], xy[:, 1], c=values, cmap="viridis", s=10)
+    # sc.get_label() == "" by default; set_array() already called by scatter
+    yield f
+    plt.close(f)
+
+
+@pytest.fixture
+def categorical_with_legend_fig():
+    """Standard plot: PathCollections with an explicit ax.legend()."""
+    f, ax = plt.subplots()
+    rng = np.random.default_rng(2)
+    categories = ["Alpha", "Beta"]
+    colors = ["#ff7f00", "#984ea3"]
+    for cat, col in zip(categories, colors):
+        xy = rng.standard_normal((20, 2))
+        ax.scatter(xy[:, 0], xy[:, 1], c=col, label=cat)
+    ax.legend()
+    yield f
+    plt.close(f)
+
+
+# ── _continuous_artists ───────────────────────────────────────────────────────
+
+def test_continuous_artists_detects_unlabeled_scatter(continuous_umap_fig):
+    artists = list(_continuous_artists(continuous_umap_fig))
+    assert len(artists) == 1
+
+
+def test_continuous_artists_ignores_categorical_scatter(categorical_umap_fig):
+    artists = list(_continuous_artists(categorical_umap_fig))
+    assert len(artists) == 0
+
+
+def test_continuous_artists_nolegend_label(continuous_umap_fig):
+    ax = continuous_umap_fig.axes[0]
+    ax.collections[0].set_label("_nolegend_")
+    artists = list(_continuous_artists(continuous_umap_fig))
+    assert len(artists) == 1
+
+
+# ── _labeled_artists ──────────────────────────────────────────────────────────
+
+def test_labeled_artists_no_legend_fallback(categorical_umap_fig):
+    ax = categorical_umap_fig.axes[0]
+    result = list(_labeled_artists(ax))
+    labels = [lbl for _, lbl in result]
+    assert labels == ["T cell", "B cell", "NK cell"]
+
+
+def test_labeled_artists_with_legend(categorical_with_legend_fig):
+    ax = categorical_with_legend_fig.axes[0]
+    result = list(_labeled_artists(ax))
+    labels = [lbl for _, lbl in result]
+    assert set(labels) == {"Alpha", "Beta"}
+
+
+def test_labeled_artists_empty_on_continuous(continuous_umap_fig):
+    ax = continuous_umap_fig.axes[0]
+    result = list(_labeled_artists(ax))
+    assert result == []
+
+
+# ── detect_plot_type / get_line_labels / get_line_colors ─────────────────────
+
+def test_detect_categorical_umap(categorical_umap_fig):
+    assert S.detect_plot_type(categorical_umap_fig) == "categorical"
+
+
+def test_detect_continuous_umap(continuous_umap_fig):
+    assert S.detect_plot_type(continuous_umap_fig) == "continuous"
+
+
+def test_get_line_labels_categorical(categorical_umap_fig):
+    labels = S.get_line_labels(categorical_umap_fig)
+    assert labels == ["T cell", "B cell", "NK cell"]
+
+
+def test_get_line_colors_categorical(categorical_umap_fig):
+    colors = S.get_line_colors(categorical_umap_fig)
+    assert len(colors) == 3
+    for c in colors:
+        assert c.startswith("#")
+
+
+def test_get_line_labels_continuous(continuous_umap_fig):
+    assert S.get_line_labels(continuous_umap_fig) == []
+
+
+# ── set_line_colors_manual ────────────────────────────────────────────────────
+
+def test_set_line_colors_manual_categorical(categorical_umap_fig):
+    new_colors = ["#111111", "#222222", "#333333"]
+    S.set_line_colors_manual(categorical_umap_fig, new_colors)
+    result = S.get_line_colors(categorical_umap_fig)
+    assert result == new_colors
+
+
+# ── palette= kwarg on studio() ────────────────────────────────────────────────
+
+def test_studio_palette_kwarg(categorical_umap_fig):
+    """studio() must accept palette= without raising."""
+    import ipywidgets as widgets
+    from unittest.mock import patch
+    from IPython.display import display as ipy_display
+
+    palette = {"T cell": "#e41a1c", "B cell": "#377eb8", "NK cell": "#4daf4a"}
+    with patch("IPython.display.display"):
+        import mplstudio
+        mplstudio.studio(categorical_umap_fig, palette=palette)


### PR DESCRIPTION
## Summary

Scanpy UMAP support + palette= kwarg, plus three follow-up fixes.

### Core (closes #11)
- `_artists.py`: `_continuous_artists` detects unlabeled/`_nolegend_` `PathCollection` with `set_array()` (continuous UMAP); `_labeled_artists` falls back to direct collection scan when no `ax.legend()` (categorical UMAP)
- `_ctx.py` / `_studio.py`: `palette: dict[str, str] | None = None` parameter on `studio()` → forwarded to `_PanelCtx`
- `colors.py`: **Custom** mode when `palette=` is supplied — applies label→hex mapping, pre-fills Manual pickers

### PathCollection color/alpha fix (closes #27)
- `_set_artist_color`: preserves existing facecolor alpha; only syncs edgecolor when originally visible
- `_opacity.py`: reads effective alpha from facecolor RGBA channel (not artist-level) for `PathCollection`; clears artist-level alpha after setting to prevent double-multiplication

### Smart mode hidden (closes #28)
- "Smart" removed from Colors ToggleButtons options; logic kept in code

### Ticks section (closes #29)
- New `style/_ticks.py`: `set_tick_labels_visible`, `set_xtick_rotation`, `set_tick_interval`
- New `widget/_sections/ticks.py`: X/Y label On/Off toggles, x-rotation slider (0°–90°, step 15°), X/Y interval text inputs

### Notebook
- `examples/scanpy_umap.ipynb`: requires scanpy (removed synthetic fallback); covers categorical UMAP + `palette=`, continuous UMAP colormap, heatmap, violin

## Test plan

- [x] All 69 tests pass (`pytest tests/ -q`)
- [x] `_set_artist_color` preserves alpha; no double-alpha after `set_series_alpha`
- [x] Ticks section renders without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)